### PR TITLE
chore: migrate to gpui-kit 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,95 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "enumn",
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.13.1",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite 2.6.1",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +117,7 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -61,12 +151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -135,15 +242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +266,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -206,52 +310,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "ash-window"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
-dependencies = [
- "ash",
- "raw-window-handle",
- "raw-window-metal",
-]
-
-[[package]]
 name = "ashpd"
-version = "0.11.1"
+version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+checksum = "fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111"
 dependencies = [
- "async-fs",
- "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "getrandom 0.4.1",
  "serde",
  "serde_repr",
- "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.10",
- "zbus",
-]
-
-[[package]]
-name = "ashpd"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522dc9bec59923af17c43c5911cdabbacdb32ed4f955e83ecf592855618b20b5"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.2",
- "serde",
- "serde_repr",
- "url",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -328,21 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.6.1",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +412,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "parking",
  "polling 3.11.0",
- "rustix 1.1.3",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -397,7 +454,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite 2.6.1",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -423,37 +480,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.1",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -474,19 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_zip"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
-dependencies = [
- "async-compression",
- "crc32fast",
- "futures-lite 2.6.1",
- "pin-project",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +514,43 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "autocfg"
@@ -548,6 +602,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base62"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,17 +662,26 @@ dependencies = [
  "lazycell",
  "libc",
  "mach",
- "nix 0.19.1",
+ "nix",
  "num-traits",
  "uom",
  "winapi",
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
+name = "bincode"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.0",
  "cexpr",
@@ -602,7 +703,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -610,6 +720,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -639,64 +755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blade-graphics"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4deb8f595ce7f00dee3543ebf6fd9a20ea86fc421ab79600dac30876250bdae"
-dependencies = [
- "ash",
- "ash-window",
- "bitflags 2.11.0",
- "bytemuck",
- "codespan-reporting",
- "glow",
- "gpu-alloc",
- "gpu-alloc-ash",
- "hidden-trait",
- "js-sys",
- "khronos-egl",
- "libloading",
- "log",
- "mint",
- "naga",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
- "objc2-quartz-core",
- "objc2-ui-kit",
- "once_cell",
- "raw-window-handle",
- "slab",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "blade-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27142319e2f4c264581067eaccb9f80acccdde60d8b4bf57cc50cd3152f109ca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "blade-util"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6be3a82c001ba7a17b6f8e413ede5d1004e6047213f8efaf0ffc15b5c4904c"
-dependencies = [
- "blade-graphics",
- "bytemuck",
- "log",
- "profiling",
-]
-
-[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,11 +780,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -740,6 +807,16 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.1",
  "piper",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -809,27 +886,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "calloop"
-version = "0.13.0"
+name = "bzip2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.11.0",
- "log",
  "polling 3.11.0",
- "rustix 0.38.44",
+ "rustix",
  "slab",
- "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop",
- "rustix 0.38.44",
+ "rustix",
  "wayland-backend",
  "wayland-client",
 ]
@@ -918,6 +1003,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
@@ -985,6 +1071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -1077,13 +1172,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "command-fds"
-version = "0.3.2"
+name = "combine"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f849b92c694fe237ecd8fafd1ba0df7ae0d45c1df6daeb7f68ed4220d51640bd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
- "nix 0.30.1",
- "thiserror 2.0.18",
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1092,8 +1187,8 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "bzip2",
  "compression-core",
- "deflate64",
  "flate2",
  "memchr",
 ]
@@ -1111,6 +1206,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1135,9 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1244,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics2"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4583956b9806b69f73fcb23aee05eb3620efc282972f08f6a6db7504f8334d"
+checksum = "4416167a69126e617f8d0a214af0e3c1dbdeffcb100ddf72dcd1a1ac9893c146"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -1269,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "core-video"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45e71d5be22206bed53c3c3cb99315fc4c3d31b8963808c6bc4538168c4f8ef"
+checksum = "139679cc63eb9504bdbe37e37874b0247136177655f0008588781e90863afa62"
 dependencies = [
  "block",
  "core-foundation 0.10.0",
@@ -1301,21 +1409,22 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.14.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
 dependencies = [
  "bitflags 2.11.0",
- "fontdb 0.16.2",
+ "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
- "rustc-hash 1.1.0",
- "rustybuzz 0.14.1",
+ "rustc-hash 2.1.1",
  "self_cell",
+ "skrifa 0.40.0",
  "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1387,25 +1496,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.4.3"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "curl"
@@ -1445,22 +1547,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
-name = "deflate64"
-version = "0.1.10"
+name = "deranged"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1472,15 +1584,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -1499,17 +1602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -1544,14 +1636,14 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -1567,11 +1659,20 @@ dependencies = [
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1579,21 +1680,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dtor"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dunce"
@@ -1649,6 +1735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1784,17 @@ name = "enumflags2_derive"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1804,6 +1910,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1940,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "fax"
@@ -1882,6 +2002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,14 +2046,14 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand 2.3.0",
  "futures-core",
  "futures-sink",
- "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1943,10 +2069,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -1957,21 +2098,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
-dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser 0.20.0",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -1985,7 +2112,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.25.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2036,6 +2163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2210,19 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -2186,7 +2332,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.3",
+ "rustix",
  "windows-link 0.2.1",
 ]
 
@@ -2232,12 +2378,39 @@ dependencies = [
 
 [[package]]
 name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2271,22 +2444,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2295,155 +2456,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
+name = "glutin_wgl_sys"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
+ "gl_generator",
 ]
 
 [[package]]
-name = "gpu-alloc-ash"
-version = "0.7.0"
+name = "gpu-allocator"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbda7a18a29bc98c2e0de0435c347df935bf59489935d0cbd0b73f1679b6f79a"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
  "ash",
- "gpu-alloc-types",
- "tinyvec",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
 ]
 
 [[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
+name = "gpu-descriptor"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
-name = "gpui"
-version = "0.2.2"
+name = "gpui-base"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979b45cfa6ec723b6f42330915a1b3769b930d02b2d505f9697f8ca602bee707"
+checksum = "2caaf00ebe0482774dd370a82a936edf4bf19a18a0d1a39353d20ecf61f70330"
 dependencies = [
+ "aho-corasick",
  "anyhow",
- "as-raw-xcb-connection",
- "ashpd 0.11.1",
- "async-task",
- "bindgen",
- "blade-graphics",
- "blade-macros",
- "blade-util",
- "block",
- "bytemuck",
- "calloop",
- "calloop-wayland-source",
- "cbindgen",
- "cocoa 0.26.0",
- "cocoa-foundation 0.2.0",
- "core-foundation 0.10.0",
- "core-foundation-sys 0.8.7",
- "core-graphics 0.24.0",
- "core-text",
- "core-video",
- "cosmic-text",
- "ctor",
- "derive_more",
- "embed-resource",
- "etagere",
- "filedescriptor",
- "flume",
- "foreign-types",
+ "async-channel 2.5.0",
+ "chrono",
  "futures",
- "gpui-macros",
- "gpui_collections",
- "gpui_http_client",
- "gpui_media",
- "gpui_refineable",
- "gpui_semantic_version",
- "gpui_sum_tree",
- "gpui_util",
- "gpui_util_macros",
- "image",
- "inventory",
- "itertools 0.14.0",
- "libc",
- "log",
- "lyon",
- "metal",
- "naga",
- "num_cpus",
- "objc",
- "oo7",
- "open",
- "parking",
- "parking_lot",
- "pathfinder_geometry",
- "pin-project",
- "postage",
- "profiling",
- "rand 0.9.2",
+ "gpui-pre",
+ "gpui-pre-macros",
+ "gpui-pre-platform",
+ "gpui-pre-sum-tree",
+ "html5ever",
+ "instant",
+ "lsp-types",
+ "markdown",
+ "markup5ever_rcdom",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
- "resvg",
+ "regex",
+ "ropey",
  "schemars",
- "seahash",
  "serde",
  "serde_json",
- "slotmap",
  "smallvec",
  "smol",
- "stacksafe",
- "strum 0.27.2",
- "taffy",
- "thiserror 2.0.18",
- "usvg",
- "uuid",
- "waker-fn",
- "wayland-backend",
- "wayland-client",
- "wayland-cursor",
- "wayland-protocols 0.31.2",
- "wayland-protocols-plasma",
- "windows 0.61.3",
- "windows-core 0.61.2",
- "windows-numerics 0.2.0",
- "windows-registry 0.5.3",
- "x11-clipboard",
- "x11rb",
- "xkbcommon",
- "zed-font-kit",
- "zed-scap",
- "zed-xim",
+ "syntect",
+ "tracing",
+ "unicode-segmentation",
+ "web-time",
 ]
 
 [[package]]
 name = "gpui-component"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d021d46b4088d3d93a57ccdf443da85695a77272108caca2f6fe5369f584966a"
+checksum = "9bd7938c395be32cea6127b92f7206501ad1fe7e121a609de1aafdedcb4d98be"
 dependencies = [
- "aho-corasick",
  "anyhow",
  "chrono",
  "core-text",
  "enum-iterator",
- "gpui",
+ "gpui-base",
  "gpui-component-macros",
- "gpui-macros",
- "html5ever",
+ "gpui-kit-assets",
+ "gpui-pre",
+ "gpui-pre-macros",
+ "gpui-pre-sum-tree",
+ "instant",
  "itertools 0.13.0",
+ "log",
  "lsp-types",
  "markdown",
- "markup5ever_rcdom",
  "notify",
  "num-traits",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "paste",
- "regex",
+ "raw-window-handle",
+ "resvg 0.45.1",
  "ropey",
  "rust-i18n",
  "schemars",
@@ -2453,62 +2574,162 @@ dependencies = [
  "smallvec",
  "smol",
  "tracing",
- "tree-sitter",
- "tree-sitter-json",
- "unicode-segmentation",
  "uuid",
- "zed-sum-tree",
-]
-
-[[package]]
-name = "gpui-component-assets"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc6e4c6551a1a12d4e8b69c3e8eba3cef43331c8c87898a0d4d040c78c6865e"
-dependencies = [
- "anyhow",
- "gpui",
- "rust-embed",
+ "windows 0.58.0",
 ]
 
 [[package]]
 name = "gpui-component-macros"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fbc2d84bf91717b171320e6adc600d91ccb3ed259448f3b006787633c1c615"
+checksum = "dacef57cadf1ce9b05b1f1ba6b3f3fed2521fd814f548eea0e4d8e43c5857795"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
-name = "gpui-macros"
-version = "0.2.2"
+name = "gpui-kit"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb02dd63a2859714ac7b6b476937617c3c744157af1b49f7c904023a79039be"
+checksum = "b3279d239b0b9228e04511ada0131120f1d7983147586e28a69820630755569f"
 dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "gpui-base",
+ "gpui-component",
+ "gpui-kit-assets",
+ "gpui-pre",
+ "gpui-pre-platform",
+ "gpui-pre-reqwest-client",
+ "gpui-pre-web",
 ]
 
 [[package]]
-name = "gpui_collections"
-version = "0.2.2"
+name = "gpui-kit-assets"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae39dc6d3d201be97e4bc08d96dbef2bc5b5c3d5734e05786e8cc3043342351c"
+checksum = "6bb6fed67d6488fa9333b6534d17f5eaef32b83e3d7148b83a3d444a1884bd1c"
 dependencies = [
+ "anyhow",
+ "gpui-pre",
+ "gpui-pre-reqwest",
+ "log",
+ "rust-embed",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "gpui-pre"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4680a36f5977d6e0892b0e7f3a2a9248a7b8acedc2b1975c88d4eb5517a21ad"
+dependencies = [
+ "accesskit",
+ "anyhow",
+ "async-channel 2.5.0",
+ "async-task",
+ "bindgen",
+ "bitflags 2.11.0",
+ "chrono",
+ "core-video",
+ "ctor",
+ "derive_more",
+ "embed-resource",
+ "etagere",
+ "futures",
+ "futures-concurrency",
+ "getrandom 0.3.4",
+ "gpui-pre-collections",
+ "gpui-pre-http-client",
+ "gpui-pre-macros",
+ "gpui-pre-refineable",
+ "gpui-pre-scheduler",
+ "gpui-pre-shared-string",
+ "gpui-pre-sum-tree",
+ "gpui-pre-util",
+ "gpui-pre-util-macros",
+ "gpui-pre-ztracing",
+ "heapless",
+ "image",
+ "inventory",
+ "itertools 0.14.0",
+ "log",
+ "lyon",
+ "num_cpus",
+ "parking",
+ "parking_lot",
+ "pin-project",
+ "pollster 0.4.0",
+ "postage",
+ "profiling",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "regex",
+ "resvg 0.46.0",
+ "schemars",
+ "seahash",
+ "serde",
+ "serde_json",
+ "slotmap",
+ "smallvec",
+ "spin 0.10.1",
+ "strum",
+ "taffy",
+ "thiserror 2.0.18",
+ "tracing",
+ "ttf-parser",
+ "url",
+ "usvg 0.46.0",
+ "uuid",
+ "waker-fn",
+ "web-time",
+ "windows 0.62.2",
+ "zed-font-kit",
+ "zed-scap",
+]
+
+[[package]]
+name = "gpui-pre-apple"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857424013dc060944781d28363b9acbd4d3f1564fdba1667d01e45327cd38f4"
+dependencies = [
+ "anyhow",
+ "block",
+ "cbindgen",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.0",
+ "core-video",
+ "derive_more",
+ "etagere",
+ "foreign-types",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "image",
+ "log",
+ "metal",
+ "objc",
+ "parking_lot",
+]
+
+[[package]]
+name = "gpui-pre-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5616f4d4b6eacaea1e9981302de24182f2ba5aedb42105a5db546817d6c758e"
+dependencies = [
+ "gpui-pre-util",
  "indexmap",
  "rustc-hash 2.1.1",
 ]
 
 [[package]]
-name = "gpui_derive_refineable"
-version = "0.2.2"
+name = "gpui-pre-derive-refineable"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644de174341a87b3478bd65b66bca38af868bcf2b2e865700523734f83cfc664"
+checksum = "60ce84a0ed2c928a804c5282a652f13c08ed7d92c051f9418885a64bb5c4c5e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,140 +2737,445 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpui_http_client"
-version = "0.2.2"
+name = "gpui-pre-http-client"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23822b0a6d2c5e6a42507980a0ab3848610ea908942c8ef98187f646f690335e"
+checksum = "075dbabc10a53661cb8adc91798b791c471541495e4dd75f38db689d7dbbc265"
 dependencies = [
  "anyhow",
  "async-compression",
- "async-fs",
  "bytes",
  "derive_more",
  "futures",
- "gpui_util",
  "http 1.4.0",
  "http-body",
  "log",
  "parking_lot",
  "serde",
  "serde_json",
- "sha2",
- "tempfile",
+ "serde_urlencoded",
  "url",
- "zed-async-tar",
- "zed-reqwest",
 ]
 
 [[package]]
-name = "gpui_media"
-version = "0.2.2"
+name = "gpui-pre-http-client-tls"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cb8912ae17371725132d2b7eec6797a255accc95d58ee5c1134b529810f14b"
+checksum = "861f4b4e406659230ddd53ee90b6d6ce1757d26093bd6e63bf0ce40adb3c936c"
+dependencies = [
+ "log",
+ "rustls",
+ "rustls-platform-verifier",
+ "webpki-roots",
+]
+
+[[package]]
+name = "gpui-pre-linux"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5081fc3154f6d7cceaf7843e665567dc46837b2f4756e86a1a69128306775a16"
+dependencies = [
+ "accesskit",
+ "accesskit_unix",
+ "anyhow",
+ "as-raw-xcb-connection",
+ "ashpd",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "calloop",
+ "calloop-wayland-source",
+ "filedescriptor",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-http-client",
+ "gpui-pre-util",
+ "gpui-pre-wgpu",
+ "libc",
+ "log",
+ "notify-rust",
+ "oo7",
+ "open",
+ "parking_lot",
+ "raw-window-handle",
+ "smallvec",
+ "smol",
+ "strum",
+ "url",
+ "uuid",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "wayland-protocols-wlr",
+ "x11-clipboard",
+ "x11rb",
+ "xkbcommon",
+ "zed-scap",
+ "zed-xim",
+]
+
+[[package]]
+name = "gpui-pre-macos"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a1e7a41b11c83b121b7bf729537c5b46dad91ef0cf221851cfb287cbe0fe33"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "anyhow",
+ "async-task",
+ "block",
+ "block2 0.6.2",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys 0.8.7",
+ "core-graphics 0.24.0",
+ "core-text",
+ "ctor",
+ "dispatch2",
+ "foreign-types",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-apple",
+ "gpui-pre-collections",
+ "gpui-pre-media",
+ "gpui-pre-util",
+ "image",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "mach2",
+ "metal",
+ "objc",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-user-notifications",
+ "parking_lot",
+ "pathfinder_geometry",
+ "raw-window-handle",
+ "semver",
+ "smallvec",
+ "strum",
+ "uuid",
+ "zed-font-kit",
+]
+
+[[package]]
+name = "gpui-pre-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c437177b89edb6c31b56665e36ef55654246629a39d7c6fa93f0673bfdab135a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "gpui-pre-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8457d57bc74a355c2790beaadbca1ec20a1359e26057029e12a16c2953c82d"
 dependencies = [
  "anyhow",
  "bindgen",
  "core-foundation 0.10.0",
  "core-video",
- "ctor",
  "foreign-types",
  "metal",
  "objc",
 ]
 
 [[package]]
-name = "gpui_perf"
-version = "0.2.2"
+name = "gpui-pre-perf"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40a0961dcf598955130e867f4b731150a20546427b41b1a63767c1037a86d77"
+checksum = "015fd7f0d39e0b2a5843dcc75ed3115542c1685064b049df9dcc7e1c3fcdb1f2"
 dependencies = [
- "gpui_collections",
+ "gpui-pre-collections",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "gpui_refineable"
-version = "0.2.2"
+name = "gpui-pre-platform"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258cb099254e9468181aee5614410fba61db4ae115fc1d51b4a0b985f60d6641"
+checksum = "2639dfde98d3a045711e986bb76ee9e727c90940ace09066d1173d6973a05beb"
 dependencies = [
- "gpui_derive_refineable",
+ "console_error_panic_hook",
+ "gpui-pre",
+ "gpui-pre-linux",
+ "gpui-pre-macos",
+ "gpui-pre-web",
+ "gpui-pre-windows",
 ]
 
 [[package]]
-name = "gpui_semantic_version"
-version = "0.2.2"
+name = "gpui-pre-refineable"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201e45eff7b695528fb3af6560a534943fbc2db5323d755b9d198bd743948e35"
+checksum = "1d21f025544f210ec7efe9eff6a46123c89a522db8278f551e8499ad84f25713"
 dependencies = [
- "anyhow",
+ "gpui-pre-derive-refineable",
+]
+
+[[package]]
+name = "gpui-pre-reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05be23908e707966824f8c51a609904b7f30739e8d915e120a53c1b995ba964c"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "windows-registry 0.4.0",
 ]
 
 [[package]]
-name = "gpui_sum_tree"
-version = "0.2.2"
+name = "gpui-pre-reqwest-client"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f3bedd573fafafa13d1200b356c588cf094fb2786e3684bb3f5ea59b549fa9"
-dependencies = [
- "arrayvec",
- "log",
- "rayon",
-]
-
-[[package]]
-name = "gpui_util"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68faea25903ae524de9af83990b9aa51bcbc8dd085929ac0aea7fd41905e05c3"
+checksum = "cf377579e784a3011733c8dc79c0980a2ad995e9c337bbd26e7c19315fa024f3"
 dependencies = [
  "anyhow",
- "async-fs",
- "async_zip",
- "command-fds",
- "dirs 4.0.0",
- "dunce",
+ "bytes",
  "futures",
- "futures-lite 1.13.0",
- "globset",
- "gpui_collections",
- "itertools 0.14.0",
- "libc",
+ "gpui-pre-http-client",
+ "gpui-pre-http-client-tls",
+ "gpui-pre-reqwest",
+ "gpui-pre-util",
  "log",
- "nix 0.29.0",
  "regex",
- "rust-embed",
+ "tokio",
+]
+
+[[package]]
+name = "gpui-pre-scheduler"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784d312d5991e219d63de75ca76af814a97d5f3c0c0a3092ff8e02c9a9a67584"
+dependencies = [
+ "async-task",
+ "backtrace",
+ "chrono",
+ "flume",
+ "futures",
+ "parking_lot",
+ "rand 0.9.2",
+ "wasm_thread",
+ "web-time",
+]
+
+[[package]]
+name = "gpui-pre-shared-string"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0972f7482d216f25eaf8ef8fd1a2e997fc54faa31288545b56e12477207acb"
+dependencies = [
  "schemars",
  "serde",
- "serde_json",
- "serde_json_lenient",
- "shlex",
- "smol",
- "take-until",
- "tempfile",
- "tendril",
- "unicase",
- "walkdir",
+ "smol_str",
+]
+
+[[package]]
+name = "gpui-pre-sum-tree"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1a771984833db84f32ef20e610723b1785666ba278ccc5af8c82cabc69a235"
+dependencies = [
+ "gpui-pre-ztracing",
+ "heapless",
+ "log",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "gpui-pre-util"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f90500cb8417942bff9f6bde0f10f7c95f80f2ea1854f6f239e2bc3d54250"
+dependencies = [
+ "anyhow",
+ "log",
  "which",
 ]
 
 [[package]]
-name = "gpui_util_macros"
-version = "0.2.2"
+name = "gpui-pre-util-macros"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c28f65ef47fb97e21e82fd4dd75ccc2506eda010c846dc8054015ea234f1a22"
+checksum = "80696f1438357c866b7acf5f67c461640af58811b6363520117b11f170436d46"
 dependencies = [
- "gpui_perf",
+ "gpui-pre-perf",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
-name = "grid"
-version = "0.18.0"
+name = "gpui-pre-web"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12101ecc8225ea6d675bc70263074eab6169079621c2186fe0c66590b2df9681"
+checksum = "d6a2d6b81bb1899d7075e1c9b431560c4fede73ea70a4ae3bf24c1b7d26db282"
+dependencies = [
+ "anyhow",
+ "console_error_panic_hook",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-http-client",
+ "gpui-pre-scheduler",
+ "gpui-pre-wgpu",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "raw-window-handle",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm_thread",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "gpui-pre-wgpu"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fdfa74b58d2af3a12b0f7373a9c23d6fe6b57e30cff9be6e26c372a85a544"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cosmic-text",
+ "etagere",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-util",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "swash",
+ "unicode-bidi",
+ "unicode-segmentation",
+ "web-sys",
+ "wgpu",
+ "zed-font-kit",
+]
+
+[[package]]
+name = "gpui-pre-windows"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682040da1444801c80ff0d885956467cc087429824c77aa9c0dfeb27e5105dfc"
+dependencies = [
+ "accesskit",
+ "accesskit_windows",
+ "anyhow",
+ "dunce",
+ "etagere",
+ "futures",
+ "gpui-pre",
+ "gpui-pre-collections",
+ "gpui-pre-util",
+ "image",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "smallvec",
+ "uuid",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-numerics 0.3.1",
+ "windows-registry 0.6.1",
+]
+
+[[package]]
+name = "gpui-pre-zlog"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca0ec69a7d108de749b9c4b320e61ab69979e0595e842da7d90c914452cf81c"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "gpui-pre-collections",
+ "log",
+]
+
+[[package]]
+name = "gpui-pre-ztracing"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24592002b47c1aa517053b870b57a0370f090d499384e09c55e8b29224a2a3d"
+dependencies = [
+ "gpui-pre-zlog",
+ "gpui-pre-ztracing-macro",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "gpui-pre-ztracing-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f82b48b20d2eec9d121f2fc8cf7ac3e917455ad05482fa2cb87260e50e6790"
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
 
 [[package]]
 name = "h2"
@@ -2683,6 +3209,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.37.0",
+ "smallvec",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,7 +3242,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2702,6 +3250,21 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -2734,17 +3297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "hidden-trait"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ed9e850438ac849bec07e7d09fbe9309cbd396a5988c30b010580ce08860df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,15 +3312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3052,7 +3595,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.14.1",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -3081,6 +3624,12 @@ name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "imgref"
@@ -3137,6 +3686,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3265,6 +3817,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,11 +3886,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3292,7 +3903,14 @@ checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
@@ -3326,12 +3944,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
+name = "kurbo"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
- "log",
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -3339,9 +3960,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -3375,6 +3993,12 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -3442,10 +4066,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "linebender_resource_handle"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3458,6 +4094,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3565,10 +4207,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -3588,6 +4253,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
 dependencies = [
+ "serde",
  "unicode-id",
 ]
 
@@ -3598,7 +4264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -3663,13 +4329,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.11.0",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "foreign-types",
  "log",
  "objc",
@@ -3709,12 +4375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mint"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,36 +4398,37 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "25.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.0",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "strum 0.26.3",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
+name = "ndk-sys"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "getrandom 0.2.17",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3789,28 +4450,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.29.0"
+name = "nohash-hasher"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3866,6 +4509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite 2.6.1",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "notify-types"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,6 +4538,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3909,16 +4575,16 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.6"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+checksum = "a7f9a86e097b0d187ad0e65667c2f58b9254671e86e7dbb78036b16692eae099"
 dependencies = [
- "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "once_cell",
+ "rand 0.9.2",
  "serde",
  "smallvec",
  "zeroize",
@@ -3932,6 +4598,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4017,6 +4689,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,27 +4715,154 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-cloud-kit",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4058,61 +4873,111 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.3.1"
+name = "objc2-io-surface"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f246c183239540aab1782457b35ab2040d4259175bd1d0c58e46ada7b47a874"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
 name = "objc2-quartz-core"
-version = "0.3.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
- "objc2-metal",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
-name = "objc2-ui-kit"
-version = "0.3.1"
+name = "objc2-quartz-core"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-core-location",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -4153,9 +5018,7 @@ dependencies = [
  "clap",
  "color-thief",
  "dirs 6.0.0",
- "gpui",
- "gpui-component",
- "gpui-component-assets",
+ "gpui-kit",
  "image",
  "isahc",
  "palette",
@@ -4164,7 +5027,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
- "sysinfo 0.38.2",
+ "sysinfo 0.38.4",
 ]
 
 [[package]]
@@ -4181,12 +5044,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oo7"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3299dd401feaf1d45afd8fd1c0586f10fcfb22f244bb9afa942cec73503b89d"
+checksum = "78f2bfed90f1618b4b48dcad9307f25e14ae894e2949642c87c351601d62cebd"
 dependencies = [
  "aes",
- "ashpd 0.12.2",
+ "ashpd",
  "async-fs",
  "async-io",
  "async-lock",
@@ -4197,15 +5060,15 @@ dependencies = [
  "endi",
  "futures-lite 2.6.1",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "hkdf",
  "hmac",
  "md-5",
  "num",
  "num-bigint-dig",
  "pbkdf2",
- "rand 0.9.2",
  "serde",
+ "serde_bytes",
  "sha2",
  "subtle",
  "zbus",
@@ -4256,6 +5119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,7 +5146,7 @@ dependencies = [
  "approx",
  "fast-srgb8",
  "palette_derive",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -4377,8 +5249,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4387,8 +5270,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4397,8 +5280,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand 2.3.0",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4407,8 +5300,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4419,6 +5325,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4530,7 +5445,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4545,6 +5460,30 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postage"
@@ -4573,6 +5512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4588,6 +5533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,33 +5550,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4654,16 +5583,6 @@ checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
-dependencies = [
- "ar_archive_writer",
- "cc",
 ]
 
 [[package]]
@@ -4701,9 +5620,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4838,6 +5757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4901,14 +5826,14 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "raw-window-metal"
-version = "0.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8caa82e31bb98fee12fa8f051c94a6aa36b07cddb03f0d4fc558988360ff1"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "cocoa 0.25.0",
- "core-graphics 0.23.2",
- "objc",
- "raw-window-handle",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -4938,16 +5863,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.10.1",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "read-fonts"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
- "bitflags 1.3.2",
+ "bytemuck",
+ "core_maths",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -5040,17 +5967,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "resvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
+ "gif 0.13.3",
+ "image-webp",
  "log",
  "pico-args",
  "rgb",
- "svgtypes",
+ "svgtypes 0.15.3",
  "tiny-skia",
- "usvg",
+ "usvg 0.45.1",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "resvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+dependencies = [
+ "gif 0.14.1",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes 0.16.1",
+ "tiny-skia",
+ "usvg 0.46.0",
+ "zune-jpeg 0.5.12",
 ]
 
 [[package]]
@@ -5059,15 +6012,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "pollster 0.4.0",
  "raw-window-handle",
@@ -5075,7 +6028,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.10",
+ "wayland-protocols",
  "web-sys",
  "windows-sys 0.61.2",
 ]
@@ -5119,6 +6072,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,12 +6118,11 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n"
-version = "3.1.5"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+checksum = "f10cee36dd3b1f7929ea12b759de9eea9eff83bfccbc71f387ef4d41a57c64a4"
 dependencies = [
  "globwalk",
- "once_cell",
  "regex",
  "rust-i18n-macro",
  "rust-i18n-support",
@@ -5170,43 +6131,43 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-macro"
-version = "3.1.5"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+checksum = "f0bb1ed4e04fe26c2a2652cad1c6595efaf7196f4445c0d6e13c67154347fb7e"
 dependencies = [
  "glob",
- "once_cell",
  "proc-macro2",
  "quote",
  "rust-i18n-support",
  "serde",
  "serde_json",
- "serde_yaml",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "rust-i18n-support"
-version = "3.1.5"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+checksum = "ba1c083408a2733180ae0acf2897612f8ceec7b0c0dcd065a0a87103bfb3b1d9"
 dependencies = [
  "arc-swap",
  "base62",
  "globwalk",
  "itertools 0.11.0",
- "lazy_static",
  "normpath",
- "once_cell",
- "proc-macro2",
- "regex",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "siphasher",
  "toml 0.8.23",
  "triomphe",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -5231,19 +6192,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -5251,7 +6199,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -5261,6 +6209,8 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5301,11 +6251,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys 0.8.7",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5319,23 +6297,6 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.21.1",
- "unicode-bidi-mirroring 0.2.0",
- "unicode-ccc 0.2.0",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
-name = "rustybuzz"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
@@ -5345,9 +6306,9 @@ dependencies = [
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser 0.25.1",
- "unicode-bidi-mirroring 0.4.0",
- "unicode-ccc 0.4.0",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
  "unicode-properties",
  "unicode-script",
 ]
@@ -5477,6 +6438,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -5486,6 +6451,35 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5543,19 +6537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json_lenient"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
-dependencies = [
- "indexmap",
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5597,19 +6578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5624,6 +6592,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -5658,6 +6635,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,6 +6652,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -5688,7 +6681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.35.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.37.0",
 ]
 
 [[package]]
@@ -5742,9 +6745,13 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "socket2"
@@ -5766,10 +6773,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+name = "spin"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5779,40 +6795,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stacker"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "stacksafe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9c1172965d317e87ddb6d364a040d958b40a1db82b6ef97da26253a8b3d090"
-dependencies = [
- "stacker",
- "stacksafe-macro",
-]
-
-[[package]]
-name = "stacksafe-macro"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172175341049678163e979d9107ca3508046d4d2a7c6682bee46ac541b17db69"
-dependencies = [
- "proc-macro-error2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "static_assertions"
@@ -5825,12 +6807,6 @@ name = "str_indices"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
-
-[[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strict-num"
@@ -5849,7 +6825,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -5860,8 +6836,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -5874,40 +6850,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6011,7 +6965,17 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
+ "siphasher",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo 0.13.1",
  "siphasher",
 ]
 
@@ -6021,16 +6985,16 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
- "skrifa",
+ "skrifa 0.37.0",
  "yazi",
  "zeno",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6039,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6069,6 +7033,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
 name = "sys-locale"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6093,9 +7075,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -6128,21 +7110,15 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e5d13f79d558b5d353a98072ca8ca0e99da429467804de959aa8c83c9a004"
+checksum = "c034e05f6ee85a12daa63863c2245797715075c70649947aa0da54f3f2ab1d0f"
 dependencies = [
  "arrayvec",
- "grid",
  "serde",
  "slotmap",
+ "smallvec",
 ]
-
-[[package]]
-name = "take-until"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdb6fa0dfa67b38c1e66b7041ba9dcf23b99d8121907cd31c807a332f7a0bbb"
 
 [[package]]
 name = "tao-core-video-sys"
@@ -6157,6 +7133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6165,7 +7152,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -6230,6 +7217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,6 +7238,25 @@ dependencies = [
  "weezl",
  "zune-jpeg 0.4.21",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tiny-keccak"
@@ -6376,7 +7391,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6398,6 +7413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6408,19 +7432,19 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6429,7 +7453,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6501,6 +7525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -6514,34 +7539,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter"
-version = "0.25.10"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "cc",
- "regex",
- "regex-syntax",
- "serde_json",
- "streaming-iterator",
- "tree-sitter-language",
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
-name = "tree-sitter-json"
-version = "0.24.8"
+name = "tracing-subscriber"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "cc",
- "tree-sitter-language",
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
-
-[[package]]
-name = "tree-sitter-language"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "triomphe"
@@ -6559,18 +7579,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttf-parser"
@@ -6618,21 +7626,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
-
-[[package]]
-name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ccc"
@@ -6695,12 +7691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6726,7 +7716,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -6738,17 +7727,44 @@ dependencies = [
  "base64",
  "data-url",
  "flate2",
- "fontdb 0.23.0",
- "imagesize",
- "kurbo",
+ "fontdb",
+ "imagesize 0.13.0",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
- "rustybuzz 0.20.1",
+ "roxmltree 0.20.0",
+ "rustybuzz",
  "simplecss",
  "siphasher",
  "strict-num",
- "svgtypes",
+ "svgtypes 0.15.3",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.14.0",
+ "kurbo 0.13.1",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes 0.16.1",
  "tiny-skia-path",
  "unicode-bidi",
  "unicode-script",
@@ -6797,6 +7813,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -6917,9 +7939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6930,23 +7952,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6954,9 +7972,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6967,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -7010,6 +8028,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm_thread"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7516db7f32decdadb1c3b8deb1b7d78b9df7606c5cc2f6241737c2ab3a0258e"
+dependencies = [
+ "futures",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7023,13 +8053,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.1.3",
+ "log",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7037,12 +8068,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
  "bitflags 2.11.0",
- "rustix 1.1.3",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7053,28 +8084,16 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5864c4b5b6064b06b1e8b74ead4a98a6c45a285fe7a0e784d24735f011fdb078"
 dependencies = [
- "rustix 1.1.3",
+ "rustix",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -7084,33 +8103,46 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -7120,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7139,21 +8171,214 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "which"
-version = "6.0.3"
+name = "wgpu"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "8.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7194,6 +8419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7267,6 +8502,19 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -7326,6 +8574,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -7340,6 +8599,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7402,13 +8672,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7416,6 +8686,15 @@ name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7436,6 +8715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7572,6 +8861,15 @@ name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7724,6 +9022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7732,12 +9039,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wio"
@@ -7837,12 +9138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7877,7 +9172,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "rustix 1.1.3",
+ "rustix",
  "x11rb-protocol",
  "xcursor",
 ]
@@ -7887,15 +9182,6 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "xcb"
@@ -7950,6 +9236,12 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xml5ever"
@@ -8036,16 +9328,40 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix 1.1.3",
+ "rustix",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.14",
  "zbus_macros",
  "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
  "zvariant",
 ]
 
@@ -8061,32 +9377,39 @@ dependencies = [
  "syn 2.0.117",
  "zbus_names",
  "zvariant",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.4",
  "zvariant",
 ]
 
 [[package]]
-name = "zed-async-tar"
-version = "0.5.0-zed"
+name = "zbus_xml"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf4b5f655e29700e473cb1acd914ab112b37b62f96f7e642d5fc6a0c02eb881"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
- "async-std",
- "filetime",
- "libc",
- "pin-project",
- "redox_syscall 0.2.16",
- "xattr",
+ "serde",
+ "winnow 1.0.4",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8115,56 +9438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zed-reqwest"
-version = "0.12.15-zed"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2d05756ff48539950c3282ad7acf3817ad3f08797c205ad1c34a2ce03b9970"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-rustls",
- "tokio-socks",
- "tokio-util",
- "tower",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "windows-registry 0.4.0",
-]
-
-[[package]]
 name = "zed-scap"
 version = "0.0.8-zed"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8184,18 +9457,6 @@ dependencies = [
  "windows-capture",
  "x11",
  "xcb",
-]
-
-[[package]]
-name = "zed-sum-tree"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d490156d0d7311855564d6e1d6dccab992405a0c0e15e1c8ef18920c02177e35"
-dependencies = [
- "arrayvec",
- "log",
- "rayon",
- "workspace-hack",
 ]
 
 [[package]]
@@ -8359,30 +9620,31 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.9.2"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
- "winnow",
+ "serde_bytes",
+ "winnow 1.0.4",
+ "zcheapstr",
  "zvariant_derive",
- "zvariant_utils",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.2"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "zvariant_utils",
+ "syn 3.0.4",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -8395,5 +9657,18 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.4",
+ "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ include = [
 ]
 
 [dependencies]
-gpui = { version = "0.2.2" }
-gpui-component = "0.5.1"
-gpui-component-assets = "0.5.1"
+gpui-kit = "0.6.0"
 anyhow = "1.0.101"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,4 +1,4 @@
-use gpui::*;
+use gpui_kit::*;
 use rust_embed::RustEmbed;
 use std::borrow::Cow;
 use std::path::Path;
@@ -79,10 +79,10 @@ impl AssetSource for OmarchistAssets {
     }
 }
 
-// Combined asset source that tries OmarchistAssets first, then gpui_component_assets
+// Combined asset source that tries OmarchistAssets first, then gpui_kit::assets
 pub struct CombinedAssets {
     omarchist: OmarchistAssets,
-    gpui_component: gpui_component_assets::Assets,
+    gpui_kit: gpui_kit::assets::Assets,
 }
 
 impl Default for CombinedAssets {
@@ -95,7 +95,7 @@ impl CombinedAssets {
     pub fn new() -> Self {
         Self {
             omarchist: OmarchistAssets,
-            gpui_component: gpui_component_assets::Assets,
+            gpui_kit: gpui_kit::assets::Assets,
         }
     }
 }
@@ -111,13 +111,13 @@ impl AssetSource for CombinedAssets {
             return Ok(Some(data));
         }
 
-        // Fall back to gpui_component_assets
-        self.gpui_component.load(path)
+        // Fall back to gpui_kit::assets
+        self.gpui_kit.load(path)
     }
 
     fn list(&self, path: &str) -> Result<Vec<SharedString>> {
         let mut results = self.omarchist.list(path)?;
-        results.extend(self.gpui_component.list(path)?);
+        results.extend(self.gpui_kit.list(path)?);
         Ok(results)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use gpui::{App, AppContext, Application, KeyBinding, WindowOptions};
-use gpui_component::{Root, Theme, ThemeMode, ThemeSet, TitleBar};
+use gpui_kit::component::{Root, Theme, ThemeMode, ThemeSet, TitleBar};
+use gpui_kit::{App, AppContext, KeyBinding, WindowOptions};
 use omarchist::cli::{CliArgs, ViewOption};
 use omarchist::system::config::config_setup;
 use omarchist::system::config::hypr_setup;
@@ -89,7 +89,7 @@ fn main() {
     // Parse CLI arguments before starting the application
     let cli_args = CliArgs::parse_args();
 
-    let app = Application::new().with_assets(CombinedAssets::new());
+    let app = gpui_kit::application().with_assets(CombinedAssets::new());
 
     app.run(move |cx| {
         // Determine initial page from CLI arguments
@@ -110,7 +110,7 @@ fn main() {
             eprintln!("Failed to set up waybar config: {}", e);
         }
 
-        gpui_component::init(cx);
+        gpui_kit::init(cx);
         load_custom_fonts(cx);
         apply_embedded_themes(cx);
         // Apply the omarchy current theme immediately at startup, falling back to embedded theme
@@ -126,22 +126,22 @@ fn main() {
                 "large" => 18.0,
                 _ => 16.0,
             };
-            gpui_component::Theme::global_mut(cx).font_size = gpui::px(font_size_px);
+            gpui_kit::component::Theme::global_mut(cx).font_size = gpui_kit::px(font_size_px);
         }
 
         cx.on_action(|_: &app_menu::SwitchToLight, cx: &mut App| {
-            gpui_component::Theme::change(gpui_component::ThemeMode::Light, None, cx);
+            gpui_kit::component::Theme::change(gpui_kit::component::ThemeMode::Light, None, cx);
             cx.refresh_windows();
         });
         cx.on_action(|_: &app_menu::SwitchToDark, cx: &mut App| {
-            gpui_component::Theme::change(gpui_component::ThemeMode::Dark, None, cx);
+            gpui_kit::component::Theme::change(gpui_kit::component::ThemeMode::Dark, None, cx);
             cx.refresh_windows();
         });
         cx.on_action(|_: &app_menu::Quit, cx: &mut App| {
             cx.quit();
         });
         cx.on_action(|action: &app_menu::SelectFont, cx: &mut App| {
-            gpui_component::Theme::global_mut(cx).font_size = gpui::px(action.0 as f32);
+            gpui_kit::component::Theme::global_mut(cx).font_size = gpui_kit::px(action.0 as f32);
 
             // Map pixel size to font size string and save to settings
             let font_size_str = match action.0 {
@@ -169,11 +169,11 @@ fn main() {
             KeyBinding::new("ctrl-,", app_menu::NavigateToSettings, None),
             KeyBinding::new("ctrl-alt-l", app_menu::SwitchToLight, None),
             KeyBinding::new("ctrl-alt-d", app_menu::SwitchToDark, None),
-            KeyBinding::new("ctrl-z", gpui_component::input::Undo, None),
-            KeyBinding::new("ctrl-shift-z", gpui_component::input::Redo, None),
-            KeyBinding::new("ctrl-x", gpui_component::input::Cut, None),
-            KeyBinding::new("ctrl-c", gpui_component::input::Copy, None),
-            KeyBinding::new("ctrl-v", gpui_component::input::Paste, None),
+            KeyBinding::new("ctrl-z", gpui_kit::component::input::Undo, None),
+            KeyBinding::new("ctrl-shift-z", gpui_kit::component::input::Redo, None),
+            KeyBinding::new("ctrl-x", gpui_kit::component::input::Cut, None),
+            KeyBinding::new("ctrl-c", gpui_kit::component::input::Copy, None),
+            KeyBinding::new("ctrl-v", gpui_kit::component::input::Paste, None),
             KeyBinding::new("ctrl-r", app_menu::RefreshTheme, None),
             KeyBinding::new("ctrl-b", app_menu::ToggleSidebar, None),
             // Global page navigation shortcuts

--- a/src/system/ui_theme_watcher.rs
+++ b/src/system/ui_theme_watcher.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
 
-use gpui::App;
-use gpui_component::{Theme, ThemeConfig};
+use gpui_kit::App;
+use gpui_kit::component::{Theme, ThemeConfig};
 use smol::Timer;
 
 use crate::system::themes::color_utils::{
@@ -364,11 +364,6 @@ pub fn spawn_ui_theme_watcher(cx: &mut App) {
         loop {
             Timer::after(POLL_INTERVAL).await;
 
-            // Stop the loop if the app has shut down.
-            if cx.update(|_| {}).is_err() {
-                break;
-            }
-
             let current_theme_name = get_active_omarchy_theme_name();
 
             if current_theme_name != last_theme_name {
@@ -376,7 +371,7 @@ pub fn spawn_ui_theme_watcher(cx: &mut App) {
                 PENDING_UI_THEME_RELOAD.with(|flag| {
                     *flag.borrow_mut() = true;
                 });
-                let _ = cx.refresh();
+                cx.refresh();
             }
         }
     })

--- a/src/ui/about_page/about_view.rs
+++ b/src/ui/about_page/about_view.rs
@@ -1,7 +1,7 @@
-use gpui::FontWeight;
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{ActiveTheme, Icon, IconName, Sizable, button::*, h_flex, v_flex};
+use gpui_kit::FontWeight;
+use gpui_kit::component::{ActiveTheme, Icon, IconName, Sizable, button::*, h_flex, v_flex};
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::ui::menu::app_menu;
 
@@ -63,9 +63,11 @@ impl Render for AboutView {
 
         let make_btn_wrapper = |index: usize, focused_button: Option<usize>| {
             let is_focused = focused_button == Some(index);
-            div().rounded_md().when(is_focused, move |this: gpui::Div| {
-                this.border_2().border_color(focused_border)
-            })
+            div()
+                .rounded_md()
+                .when(is_focused, move |this: gpui_kit::Div| {
+                    this.border_2().border_color(focused_border)
+                })
         };
 
         v_flex()
@@ -134,7 +136,7 @@ impl Render for AboutView {
                     .child(
                         make_btn_wrapper(1, self.focused_button).child(
                             Button::new("github")
-                                .icon(Icon::new(IconName::GitHub).size_8())
+                                .icon(Icon::new(IconName::Github).size_8())
                                 .ghost()
                                 .cursor_pointer()
                                 .large()

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -10,12 +10,12 @@ use crate::ui::status_bar_page::status_bar_view::StatusBarView;
 use crate::ui::system_monitor_page::system_monitor::SystemMonitorPage;
 use crate::ui::theme_edit_page::theme_edit::ThemeEditPage;
 use crate::ui::themes_page::themes::ThemesPage;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     Collapsible, Icon, IconName, Root, Side, h_flex,
     kbd::Kbd,
-    sidebar::{Sidebar, SidebarGroup, SidebarMenu, SidebarMenuItem},
+    sidebar::{Sidebar, SidebarGroup, SidebarItem, SidebarMenu, SidebarMenuItem},
 };
+use gpui_kit::*;
 use std::cell::RefCell;
 
 use crate::system::ui_theme_watcher;
@@ -92,11 +92,9 @@ impl MainWindowView {
                 // Initial check
                 let version = get_local_omarchy_version().unwrap_or_else(|_| "unknown".to_string());
                 if let Ok(update_available) = check_omarchy_update(&version).await {
-                    title_bar_watcher
-                        .update(cx, |tb, _| {
-                            tb.set_omarchy_update_available(update_available);
-                        })
-                        .ok();
+                    title_bar_watcher.update(cx, |tb, _| {
+                        tb.set_omarchy_update_available(update_available);
+                    });
                 }
 
                 // Periodic re-checks
@@ -109,11 +107,9 @@ impl MainWindowView {
                     let version =
                         get_local_omarchy_version().unwrap_or_else(|_| "unknown".to_string());
                     if let Ok(update_available) = check_omarchy_update(&version).await {
-                        title_bar_watcher
-                            .update(cx, |tb, _| {
-                                tb.set_omarchy_update_available(update_available);
-                            })
-                            .ok();
+                        title_bar_watcher.update(cx, |tb, _| {
+                            tb.set_omarchy_update_available(update_available);
+                        });
                     }
                 }
             })
@@ -122,7 +118,7 @@ impl MainWindowView {
 
         // Create focus handle for sidebar navigation; keep it focused at start
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window);
+        focus_handle.focus(window, cx);
 
         let initial_sidebar_index = match &initial_page {
             ActivePage::Themes | ActivePage::ThemeEdit(_) => 0,
@@ -321,10 +317,10 @@ impl MainWindowView {
         };
 
         if let Some(fh) = handle {
-            fh.focus(window);
+            fh.focus(window, cx);
         } else {
             // Return focus to the main window (sidebar)
-            self.focus_handle.focus(window);
+            self.focus_handle.focus(window, cx);
         }
     }
 
@@ -416,7 +412,7 @@ impl MainWindowView {
             FocusedSection::Content => {
                 self.focus_state.focused_section = FocusedSection::Sidebar;
                 // Return GPUI focus to the main window for sidebar navigation
-                self.focus_handle.focus(window);
+                self.focus_handle.focus(window, cx);
             }
         }
         cx.notify();
@@ -432,7 +428,7 @@ impl MainWindowView {
             FocusedSection::Content => {
                 self.focus_state.focused_section = FocusedSection::Sidebar;
                 // Return GPUI focus to the main window for sidebar navigation
-                self.focus_handle.focus(window);
+                self.focus_handle.focus(window, cx);
             }
         }
         cx.notify();
@@ -466,7 +462,7 @@ impl MainWindowView {
             // Child views consume this if they still have internal items to navigate left.
             // If they bubble it up (e.g. ThemesPage at Tabs level), we move to sidebar.
             self.focus_state.focused_section = FocusedSection::Sidebar;
-            self.focus_handle.focus(window);
+            self.focus_handle.focus(window, cx);
             cx.notify();
         }
     }
@@ -481,7 +477,7 @@ impl MainWindowView {
     fn handle_escape_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.focus_state.focused_section == FocusedSection::Content {
             self.focus_state.focused_section = FocusedSection::Sidebar;
-            self.focus_handle.focus(window);
+            self.focus_handle.focus(window, cx);
             cx.notify();
         }
     }
@@ -687,7 +683,8 @@ impl Render for MainWindowView {
                     .size_full()
                     .overflow_hidden()
                     .child(
-                        Sidebar::new(Side::Left)
+                        Sidebar::new("main-sidebar")
+                            .side(Side::Left)
                             .collapsed(sidebar_should_be_collapsed)
                             .child(
                                 SidebarGroup::new("Navigation").child(
@@ -749,16 +746,16 @@ impl Render for MainWindowView {
                                         ),
                                 ),
                             )
-                            .footer(
+                            .footer(SidebarItem::render(
                                 SidebarGroup::new("")
                                     .collapsed(sidebar_should_be_collapsed)
                                     .child(
                                         SidebarMenu::new().cursor_pointer().child(
                                             SidebarMenuItem::new("Toggle Sidebar")
                                                 .icon(Icon::new(IconName::PanelLeft))
-                                                .suffix(Kbd::new(
-                                                    Keystroke::parse("ctrl-b").unwrap(),
-                                                ))
+                                                .suffix(|_, _| {
+                                                    Kbd::new(Keystroke::parse("ctrl-b").unwrap())
+                                                })
                                                 .on_click(cx.listener(|this, _, _, cx| {
                                                     this.sidebar_collapsed =
                                                         !this.sidebar_collapsed;
@@ -776,7 +773,10 @@ impl Render for MainWindowView {
                                                 })),
                                         ),
                                     ),
-                            ),
+                                "sidebar-footer",
+                                window,
+                                cx,
+                            )),
                     )
                     .child(
                         div()

--- a/src/ui/color_utils.rs
+++ b/src/ui/color_utils.rs
@@ -1,4 +1,4 @@
-use gpui::{Hsla, rgb};
+use gpui_kit::{Hsla, rgb};
 
 // Parse a #RRGGBB hex string into GPUI's Hsla type.
 pub fn hex_to_hsla(hex: &str) -> Option<Hsla> {

--- a/src/ui/config_page/config_view.rs
+++ b/src/ui/config_page/config_view.rs
@@ -1,9 +1,9 @@
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     IndexPath, Sizable as _, Size,
     select::{SearchableVec, Select, SelectEvent, SelectItem, SelectState},
     setting::{NumberFieldOptions, SettingField, SettingGroup, SettingItem, SettingPage, Settings},
 };
+use gpui_kit::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -119,7 +119,7 @@ impl Render for ConfigView {
             .child(
                 Settings::new("hyprland-config")
                     .sidebar_width(px(220.0))
-                    .with_group_variant(gpui_component::group_box::GroupBoxVariant::Normal)
+                    .with_group_variant(gpui_kit::component::group_box::GroupBoxVariant::Normal)
                     .with_size(Size::default())
                     .pages(vec![
                         self.create_general_page(&view),

--- a/src/ui/dialogs/create_theme_dialog.rs
+++ b/src/ui/dialogs/create_theme_dialog.rs
@@ -2,13 +2,14 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 
 use anyhow;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Icon, IconName, WindowExt,
     button::{Button, ButtonVariants},
-    divider::Divider,
-    h_flex, v_flex,
+    h_flex,
+    separator::Separator,
+    v_flex,
 };
+use gpui_kit::*;
 use smol;
 
 use crate::system::themes::theme_management::{
@@ -65,7 +66,7 @@ pub fn open_create_theme_dialog(window: &mut Window, cx: &mut App) {
                                     }),
                             ),
                     )
-                    .child(Divider::vertical().color(cx.theme().border))
+                    .child(Separator::vertical().color(cx.theme().border))
                     .child(
                         // Right Column - Create Manually
                         v_flex()

--- a/src/ui/dialogs/create_waybar_profile_dialog.rs
+++ b/src/ui/dialogs/create_waybar_profile_dialog.rs
@@ -1,14 +1,14 @@
 use std::cell::RefCell;
 
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Disableable, WindowExt,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{Input, InputState},
     v_flex,
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::system::waybar::create_waybar_profile;
 
@@ -50,7 +50,7 @@ pub fn open_create_waybar_profile_dialog(window: &mut Window, cx: &mut App) {
     });
 
     // Auto-focus the input field
-    focus.focus(window);
+    focus.focus(window, cx);
 }
 
 #[derive(IntoElement)]
@@ -82,7 +82,7 @@ impl RenderOnce for CreateProfileForm {
                             .child("Profile name"),
                     )
                     .child(Input::new(&self.name_input))
-                    .when(error_text.is_some(), |this: gpui::Div| {
+                    .when(error_text.is_some(), |this: gpui_kit::Div| {
                         this.child(
                             div()
                                 .text_xs()

--- a/src/ui/dialogs/manage_waybar_profile_dialogs.rs
+++ b/src/ui/dialogs/manage_waybar_profile_dialogs.rs
@@ -1,14 +1,14 @@
 use std::cell::RefCell;
 
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Disableable, WindowExt,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{Input, InputState},
     v_flex,
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::system::waybar::{
     delete_waybar_profile, duplicate_waybar_profile, rename_waybar_profile,
@@ -62,7 +62,7 @@ pub fn open_rename_waybar_profile_dialog(
             })
     });
 
-    focus.focus(window);
+    focus.focus(window, cx);
 }
 
 #[derive(IntoElement)]
@@ -98,7 +98,7 @@ impl RenderOnce for RenameProfileForm {
                             .child("New profile name"),
                     )
                     .child(Input::new(&self.name_input))
-                    .when(error_text.is_some(), |this: gpui::Div| {
+                    .when(error_text.is_some(), |this: gpui_kit::Div| {
                         this.child(
                             div()
                                 .text_xs()
@@ -189,7 +189,7 @@ pub fn open_duplicate_waybar_profile_dialog(
             })
     });
 
-    focus.focus(window);
+    focus.focus(window, cx);
 }
 
 #[derive(IntoElement)]
@@ -224,7 +224,7 @@ impl RenderOnce for DuplicateProfileForm {
                             .child(format!("New name for copy of \"{}\"", self.source_profile)),
                     )
                     .child(Input::new(&self.name_input))
-                    .when(error_text.is_some(), |this: gpui::Div| {
+                    .when(error_text.is_some(), |this: gpui_kit::Div| {
                         this.child(
                             div()
                                 .text_xs()

--- a/src/ui/dialogs/theme_creation_progress_dialog.rs
+++ b/src/ui/dialogs/theme_creation_progress_dialog.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use gpui::*;
-use gpui_component::{ActiveTheme, Icon, IconName, WindowExt, button::Button, v_flex};
+use gpui_kit::component::{ActiveTheme, Icon, IconName, WindowExt, button::Button, v_flex};
+use gpui_kit::*;
 use smol;
 
 use crate::system::themes::theme_generator::create_theme_from_image;

--- a/src/ui/menu/app_menu.rs
+++ b/src/ui/menu/app_menu.rs
@@ -1,4 +1,4 @@
-use gpui::{Action, actions};
+use gpui_kit::{Action, actions};
 
 actions!(
     app_menu,

--- a/src/ui/menu/title_bar.rs
+++ b/src/ui/menu/title_bar.rs
@@ -1,11 +1,11 @@
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
-    ActiveTheme, Icon, IconName, PixelsExt, Side, Sizable, TitleBar,
+use gpui_kit::component::{
+    ActiveTheme, Icon, IconName, Side, Sizable, TitleBar,
     button::*,
     h_flex,
     menu::{DropdownMenu, PopupMenu, PopupMenuItem},
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::ui::menu::app_menu::SelectFont;
 
@@ -123,7 +123,7 @@ impl Render for MainTitleBar {
                             .cursor_pointer()
                             .dropdown_menu(|menu: PopupMenu, _window: &mut Window, cx: &mut Context<PopupMenu>| {
                                 let font_size = cx.theme().font_size.as_f32() as i32;
-                                let is_light = cx.theme().mode == gpui_component::ThemeMode::Light;
+                                let is_light = cx.theme().mode == gpui_kit::component::ThemeMode::Light;
                                 menu.label("Font Size")
                                     .check_side(Side::Right)
                                     .menu_with_check("Large", font_size == 18, Box::new(SelectFont(18)))
@@ -138,7 +138,7 @@ impl Render for MainTitleBar {
                     )
                     .child(
                         Button::new("github")
-                            .icon(IconName::GitHub)
+                            .icon(IconName::Github)
                             .small()
                             .ghost()
                             .cursor_pointer()
@@ -152,6 +152,6 @@ impl Render for MainTitleBar {
 }
 
 pub fn handle_select_font(font_size: &SelectFont, window: &mut Window, cx: &mut App) {
-    gpui_component::Theme::global_mut(cx).font_size = gpui::px(font_size.0 as f32);
+    gpui_kit::component::Theme::global_mut(cx).font_size = gpui_kit::px(font_size.0 as f32);
     window.refresh();
 }

--- a/src/ui/omarchy_page/omarchy_view.rs
+++ b/src/ui/omarchy_page/omarchy_view.rs
@@ -1,8 +1,8 @@
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, button::Button, h_flex, text::TextView, text::TextViewStyle, v_flex,
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::system::omarchy::{
     omarchy_version::{check_omarchy_update, get_local_omarchy_version},
@@ -79,11 +79,9 @@ impl OmarchyView {
                         this.update_available = Some(update_available);
                     })
                     .ok();
-                    title_bar
-                        .update(cx, |tb, _| {
-                            tb.set_omarchy_update_available(update_available);
-                        })
-                        .ok();
+                    title_bar.update(cx, |tb, _| {
+                        tb.set_omarchy_update_available(update_available);
+                    });
                 }
                 Err(e) => {
                     eprintln!("Failed to check for omarchy updates: {e}");
@@ -136,7 +134,7 @@ impl OmarchyView {
 }
 
 impl Render for OmarchyView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let update_available = self.update_available == Some(true);
         let update_btn_focused = self.update_btn_focused && update_available;
@@ -185,7 +183,7 @@ impl Render for OmarchyView {
                             .child(
                                 div()
                                     .rounded_md()
-                                    .when(update_btn_focused, move |this: gpui::Div| {
+                                    .when(update_btn_focused, move |this: gpui_kit::Div| {
                                         this.border_2().border_color(focused_border)
                                     })
                                     .child(
@@ -238,9 +236,9 @@ impl Render for OmarchyView {
 
             let is_dark = cx.theme().mode.is_dark();
             let highlight_theme = if is_dark {
-                gpui_component::highlighter::HighlightTheme::default_dark()
+                gpui_kit::component::highlighter::HighlightTheme::default_dark()
             } else {
-                gpui_component::highlighter::HighlightTheme::default_light()
+                gpui_kit::component::highlighter::HighlightTheme::default_light()
             };
 
             let style = TextViewStyle {
@@ -256,7 +254,7 @@ impl Render for OmarchyView {
                 ..Default::default()
             };
 
-            let markdown_view = TextView::markdown("release-notes", notes.clone(), window, cx)
+            let markdown_view = TextView::markdown("release-notes", notes.clone())
                 .style(style)
                 .line_height(rems(1.6))
                 .selectable(true);

--- a/src/ui/settings_page/settings_view.rs
+++ b/src/ui/settings_page/settings_view.rs
@@ -1,5 +1,5 @@
-use gpui::*;
-use gpui_component::{ActiveTheme, h_flex, label::Label, switch::Switch, v_flex};
+use gpui_kit::component::{ActiveTheme, h_flex, label::Label, switch::Switch, v_flex};
+use gpui_kit::*;
 
 use crate::system::config::config_setup::{read_settings, save_settings};
 use crate::ui::menu::app_menu;

--- a/src/ui/status_bar_page/bar_settings.rs
+++ b/src/ui/status_bar_page/bar_settings.rs
@@ -1,12 +1,12 @@
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Disableable, Icon, IconName, IndexPath, Sizable, StyledExt, h_flex,
     input::{InputEvent, InputState, NumberInput, NumberInputEvent, StepAction},
     label::Label,
     select::{Select, SelectEvent, SelectState},
     v_flex,
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::system::waybar::{BarSettings, get_bar_settings, set_bar_setting};
 use crate::ui::status_bar_page::shared::labeled_input;
@@ -570,7 +570,7 @@ impl Render for BarSettingsPanel {
             v_flex()
                 .pt_3()
                 .gap_4()
-                .when(read_only, |this: gpui::Div| {
+                .when(read_only, |this: gpui_kit::Div| {
                     this.child(
                         div()
                             .text_xs()

--- a/src/ui/status_bar_page/design_area.rs
+++ b/src/ui/status_bar_page/design_area.rs
@@ -1,12 +1,12 @@
 // TODO: Re-enable when Add Module feature is ready
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     // IconName, Sizable,
     // button::{Button, ButtonVariants as _},
     // h_flex,
     v_flex,
 };
+use gpui_kit::*;
 
 use crate::ui::status_bar_page::bar_settings::BarSettingsPanel;
 use crate::ui::status_bar_page::module_editor::{ModuleEditorPanel, take_pending_module_edit};

--- a/src/ui/status_bar_page/header.rs
+++ b/src/ui/status_bar_page/header.rs
@@ -1,11 +1,11 @@
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Disableable, Icon, IconName, IndexPath, Sizable,
     button::{Button, ButtonVariants as _},
     h_flex,
     select::{Select, SelectState},
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::shell::waybar_sh_commands::restart_waybar;
 use crate::system::waybar::{
@@ -111,7 +111,7 @@ impl Render for StatusBarHeader {
         let can_manage_profile = !is_read_only_selected;
 
         let focus_ring = move |idx: usize| {
-            move |this: gpui::Div| {
+            move |this: gpui_kit::Div| {
                 if focused == Some(idx) {
                     this.border_2().border_color(ring)
                 } else {

--- a/src/ui/status_bar_page/module_editor.rs
+++ b/src/ui/status_bar_page/module_editor.rs
@@ -1,11 +1,11 @@
 use std::cell::RefCell;
 
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Icon, IconName, StyledExt, h_flex,
     input::{InputEvent, InputState},
     v_flex,
 };
+use gpui_kit::*;
 
 use crate::system::waybar::{get_module_config, set_module_config_field};
 use crate::ui::status_bar_page::shared::{labeled_input, labeled_input_wide};

--- a/src/ui/status_bar_page/module_library.rs
+++ b/src/ui/status_bar_page/module_library.rs
@@ -1,5 +1,4 @@
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, IconName, IndexPath, Sizable, StyledExt, WindowExt,
     button::{Button, ButtonVariants as _},
     h_flex,
@@ -7,6 +6,7 @@ use gpui_component::{
     select::{Select, SelectState},
     v_flex,
 };
+use gpui_kit::*;
 
 use std::sync::LazyLock;
 

--- a/src/ui/status_bar_page/shared.rs
+++ b/src/ui/status_bar_page/shared.rs
@@ -1,10 +1,10 @@
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     Sizable,
     input::{Input, InputState},
     label::Label,
     v_flex,
 };
+use gpui_kit::*;
 
 // Labeled input field with a fixed narrow width (160 px).
 pub fn labeled_input(

--- a/src/ui/status_bar_page/status_bar_view.rs
+++ b/src/ui/status_bar_page/status_bar_view.rs
@@ -1,6 +1,8 @@
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{ActiveTheme, Icon, IconName, StyledExt, h_flex, select::SelectEvent, v_flex};
+use gpui_kit::component::{
+    ActiveTheme, Icon, IconName, StyledExt, h_flex, select::SelectEvent, v_flex,
+};
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 use crate::shell::waybar_sh_commands::restart_waybar;
 use crate::system::waybar::{
@@ -195,10 +197,10 @@ impl Render for StatusBarView {
                         let header = this.header_entity();
                         let select = header.read(cx).select_entity();
                         let fh = {
-                            use gpui::Focusable;
+                            use gpui_kit::Focusable;
                             select.read(cx).focus_handle(cx).clone()
                         };
-                        fh.focus(window);
+                        fh.focus(window, cx);
                     }
                     Some(1) => {
                         crate::ui::dialogs::create_waybar_profile_dialog::open_create_waybar_profile_dialog(window, cx);

--- a/src/ui/status_bar_page/waybar_item.rs
+++ b/src/ui/status_bar_page/waybar_item.rs
@@ -1,9 +1,9 @@
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     menu::{ContextMenuExt, PopupMenuItem},
     tooltip::Tooltip,
 };
+use gpui_kit::*;
 
 use crate::system::waybar::{WaybarModule, WaybarZone};
 use crate::ui::status_bar_page::module_editor::request_module_edit;

--- a/src/ui/status_bar_page/waybar_preview.rs
+++ b/src/ui/status_bar_page/waybar_preview.rs
@@ -1,5 +1,5 @@
-use gpui::*;
-use gpui_component::{ActiveTheme, h_flex, v_flex};
+use gpui_kit::component::{ActiveTheme, h_flex, v_flex};
+use gpui_kit::*;
 
 use crate::system::waybar::{
     WaybarConfig, WaybarModule, WaybarZone, load_waybar_config, save_waybar_config,

--- a/src/ui/system_monitor_page/data_collector.rs
+++ b/src/ui/system_monitor_page/data_collector.rs
@@ -198,7 +198,7 @@ impl DataCollector {
         let mut total_up: u64 = 0;
         let mut total_down: u64 = 0;
 
-        for (_, network) in self.networks.iter() {
+        for network in self.networks.values() {
             total_up += network.total_transmitted();
             total_down += network.total_received();
         }
@@ -453,8 +453,8 @@ pub fn get_metric_color(
     value: f32,
     warning: f32,
     critical: f32,
-    theme: &gpui_component::Theme,
-) -> gpui::Hsla {
+    theme: &gpui_kit::component::Theme,
+) -> gpui_kit::Hsla {
     if value >= critical {
         theme.red
     } else if value >= warning {

--- a/src/ui/system_monitor_page/disks_tab.rs
+++ b/src/ui/system_monitor_page/disks_tab.rs
@@ -1,21 +1,21 @@
-use gpui::{App, AppContext, IntoElement, ParentElement, Styled, Window, div, px};
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     group_box::GroupBox,
     h_flex,
     progress::Progress,
-    table::{Column, Table, TableDelegate, TableState},
+    table::{Column, DataTable, TableDelegate, TableState},
     v_flex,
 };
+use gpui_kit::{App, AppContext, IntoElement, ParentElement, Styled, Window, div, px};
 
 use super::data_collector::{DataCollector, DiskInfo, format_bytes};
 
 pub struct DisksTab {
-    disk_table: gpui::Entity<TableState<DiskTableDelegate>>,
+    disk_table: gpui_kit::Entity<TableState<DiskTableDelegate>>,
 }
 
 impl DisksTab {
-    pub fn new(table: gpui::Entity<TableState<DiskTableDelegate>>) -> Self {
+    pub fn new(table: gpui_kit::Entity<TableState<DiskTableDelegate>>) -> Self {
         Self { disk_table: table }
     }
 
@@ -29,8 +29,8 @@ impl DisksTab {
     pub fn render(
         &self,
         collector: &DataCollector,
-        theme: &gpui_component::Theme,
-        viewport_width: gpui::Pixels,
+        theme: &gpui_kit::component::Theme,
+        viewport_width: gpui_kit::Pixels,
     ) -> impl IntoElement {
         let disks = collector.get_disks();
 
@@ -72,7 +72,7 @@ impl DisksTab {
                                         } else {
                                             px(240.0)
                                         })
-                                        .flex_grow()
+                                        .flex_grow(1.0)
                                         .min_w(if viewport_width < px(640.0) {
                                             px(0.0)
                                         } else {
@@ -85,7 +85,7 @@ impl DisksTab {
                                         .child(
                                             div()
                                                 .text_sm()
-                                                .font_weight(gpui::FontWeight::MEDIUM)
+                                                .font_weight(gpui_kit::FontWeight::MEDIUM)
                                                 .child(disk.name.clone()),
                                         )
                                         .child(div().text_xs().child(disk.mount_point.clone()))
@@ -94,10 +94,13 @@ impl DisksTab {
                                                 .gap_3()
                                                 .items_center()
                                                 .child(
-                                                    Progress::new()
-                                                        .w(px(140.0))
-                                                        .h(px(8.0))
-                                                        .value(usage_percent),
+                                                    Progress::new(format!(
+                                                        "disk-usage:{:?}",
+                                                        (&disk.name, &disk.mount_point)
+                                                    ))
+                                                    .w(px(140.0))
+                                                    .h(px(8.0))
+                                                    .value(usage_percent),
                                                 )
                                                 .child(
                                                     div()
@@ -143,7 +146,11 @@ impl DisksTab {
                         .min_h(px(150.0))
                         .flex_1()
                         .overflow_hidden()
-                        .child(Table::new(&self.disk_table).bordered(false).stripe(true)),
+                        .child(
+                            DataTable::new(&self.disk_table)
+                                .bordered(false)
+                                .stripe(true),
+                        ),
                 ),
             )
             .into_element()
@@ -153,7 +160,7 @@ impl DisksTab {
 pub fn create_disk_table(
     window: &mut Window,
     cx: &mut App,
-) -> gpui::Entity<TableState<DiskTableDelegate>> {
+) -> gpui_kit::Entity<TableState<DiskTableDelegate>> {
     let delegate = DiskTableDelegate::new();
     cx.new(|cx| {
         TableState::new(delegate, window, cx)
@@ -196,8 +203,8 @@ impl TableDelegate for DiskTableDelegate {
         self.disks.len()
     }
 
-    fn column(&self, col_ix: usize, _cx: &App) -> &Column {
-        &self.columns[col_ix]
+    fn column(&self, col_ix: usize, _cx: &App) -> Column {
+        self.columns[col_ix].clone()
     }
 
     fn render_td(
@@ -205,7 +212,7 @@ impl TableDelegate for DiskTableDelegate {
         row_ix: usize,
         col_ix: usize,
         _window: &mut Window,
-        cx: &mut gpui::Context<TableState<Self>>,
+        cx: &mut gpui_kit::Context<TableState<Self>>,
     ) -> impl IntoElement {
         let Some(disk) = self.disks.get(row_ix) else {
             return div().into_any_element();

--- a/src/ui/system_monitor_page/metric_card.rs
+++ b/src/ui/system_monitor_page/metric_card.rs
@@ -1,5 +1,5 @@
-use gpui::{IntoElement, ParentElement, Styled, div, prelude::FluentBuilder as _, px};
-use gpui_component::{Icon, h_flex, v_flex};
+use gpui_kit::component::{Icon, h_flex, v_flex};
+use gpui_kit::{IntoElement, ParentElement, Styled, div, prelude::FluentBuilder as _, px};
 
 use super::sparkline::Sparkline;
 
@@ -9,11 +9,11 @@ pub struct MetricCard {
     value: String,
     sub_value: Option<String>,
     sparkline_data: Option<Vec<f64>>,
-    color: gpui::Hsla,
-    alert_color: Option<gpui::Hsla>,
+    color: gpui_kit::Hsla,
+    alert_color: Option<gpui_kit::Hsla>,
     compact: bool,
     large: bool,
-    border_color: gpui::Hsla,
+    border_color: gpui_kit::Hsla,
 }
 
 impl MetricCard {
@@ -24,11 +24,11 @@ impl MetricCard {
             value: value.into(),
             sub_value: None,
             sparkline_data: None,
-            color: gpui::Hsla::default(),
+            color: gpui_kit::Hsla::default(),
             alert_color: None,
             compact: false,
             large: false,
-            border_color: gpui::Hsla::default(),
+            border_color: gpui_kit::Hsla::default(),
         }
     }
 
@@ -47,12 +47,12 @@ impl MetricCard {
         self
     }
 
-    pub fn color(mut self, color: gpui::Hsla) -> Self {
+    pub fn color(mut self, color: gpui_kit::Hsla) -> Self {
         self.color = color;
         self
     }
 
-    pub fn alert_color(mut self, color: gpui::Hsla) -> Self {
+    pub fn alert_color(mut self, color: gpui_kit::Hsla) -> Self {
         self.alert_color = Some(color);
         self
     }
@@ -67,14 +67,14 @@ impl MetricCard {
         self
     }
 
-    pub fn border_color(mut self, color: gpui::Hsla) -> Self {
+    pub fn border_color(mut self, color: gpui_kit::Hsla) -> Self {
         self.border_color = color;
         self
     }
 }
 
 impl IntoElement for MetricCard {
-    type Element = gpui::Div;
+    type Element = gpui_kit::Div;
 
     fn into_element(self) -> Self::Element {
         let value_color = self.alert_color.unwrap_or(self.color);
@@ -93,9 +93,9 @@ impl IntoElement for MetricCard {
             px(24.0)
         };
         let value_text_class = if self.large {
-            |d: gpui::Div| d.text_3xl()
+            |d: gpui_kit::Div| d.text_3xl()
         } else {
-            |d: gpui::Div| d.text_2xl()
+            |d: gpui_kit::Div| d.text_2xl()
         };
 
         div()
@@ -120,7 +120,7 @@ impl IntoElement for MetricCard {
                             .gap_2()
                             .child(
                                 value_text_class(div())
-                                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                                    .font_weight(gpui_kit::FontWeight::SEMIBOLD)
                                     .text_color(value_color)
                                     .child(self.value),
                             )
@@ -131,7 +131,7 @@ impl IntoElement for MetricCard {
                     .when_some(self.sparkline_data, |this, data| {
                         let sparkline_height = if self.large { px(160.0) } else { px(80.0) };
                         this.child(
-                            div().flex_grow().child(
+                            div().flex_grow(1.0).child(
                                 Sparkline::new(data)
                                     .color(self.color)
                                     .height(sparkline_height),
@@ -146,7 +146,7 @@ impl IntoElement for MetricCard {
 pub struct MiniMetric {
     icon: Icon,
     value: String,
-    color: gpui::Hsla,
+    color: gpui_kit::Hsla,
     sparkline_data: Option<Vec<f64>>,
 }
 
@@ -155,12 +155,12 @@ impl MiniMetric {
         Self {
             icon,
             value: value.into(),
-            color: gpui::Hsla::default(),
+            color: gpui_kit::Hsla::default(),
             sparkline_data: None,
         }
     }
 
-    pub fn color(mut self, color: gpui::Hsla) -> Self {
+    pub fn color(mut self, color: gpui_kit::Hsla) -> Self {
         self.color = color;
         self
     }
@@ -172,7 +172,7 @@ impl MiniMetric {
 }
 
 impl IntoElement for MiniMetric {
-    type Element = gpui::Div;
+    type Element = gpui_kit::Div;
 
     fn into_element(self) -> Self::Element {
         h_flex()
@@ -196,7 +196,7 @@ impl IntoElement for MiniMetric {
 pub struct MetricGrid {
     children: Vec<MetricCard>,
     columns: usize,
-    gap: gpui::Pixels,
+    gap: gpui_kit::Pixels,
 }
 
 impl Default for MetricGrid {
@@ -219,7 +219,7 @@ impl MetricGrid {
         self
     }
 
-    pub fn gap(mut self, gap: gpui::Pixels) -> Self {
+    pub fn gap(mut self, gap: gpui_kit::Pixels) -> Self {
         self.gap = gap;
         self
     }
@@ -231,7 +231,7 @@ impl MetricGrid {
 }
 
 impl IntoElement for MetricGrid {
-    type Element = gpui::Div;
+    type Element = gpui_kit::Div;
 
     fn into_element(self) -> Self::Element {
         let mut grid = div().flex().flex_wrap().gap(self.gap);
@@ -241,7 +241,7 @@ impl IntoElement for MetricGrid {
                 div()
                     .flex()
                     .flex_basis(px(0.0))
-                    .flex_grow()
+                    .flex_grow(1.0)
                     .min_w(px(240.0))
                     .child(card),
             );

--- a/src/ui/system_monitor_page/network_tab.rs
+++ b/src/ui/system_monitor_page/network_tab.rs
@@ -1,21 +1,21 @@
-use gpui::{App, AppContext, IntoElement, ParentElement, Styled, Window, div, px};
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     chart::AreaChart,
     group_box::GroupBox,
     h_flex,
-    table::{Column, Table, TableDelegate, TableState},
+    table::{Column, DataTable, TableDelegate, TableState},
     v_flex,
 };
+use gpui_kit::{App, AppContext, IntoElement, ParentElement, Styled, Window, div, px};
 
 use super::data_collector::{DataCollector, InterfaceInfo, format_bytes, format_bytes_speed};
 
 pub struct NetworkTab {
-    interface_table: gpui::Entity<TableState<InterfaceTableDelegate>>,
+    interface_table: gpui_kit::Entity<TableState<InterfaceTableDelegate>>,
 }
 
 impl NetworkTab {
-    pub fn new(table: gpui::Entity<TableState<InterfaceTableDelegate>>) -> Self {
+    pub fn new(table: gpui_kit::Entity<TableState<InterfaceTableDelegate>>) -> Self {
         Self {
             interface_table: table,
         }
@@ -31,8 +31,8 @@ impl NetworkTab {
     pub fn render(
         &self,
         collector: &DataCollector,
-        theme: &gpui_component::Theme,
-        viewport_width: gpui::Pixels,
+        theme: &gpui_kit::component::Theme,
+        viewport_width: gpui_kit::Pixels,
     ) -> impl IntoElement {
         let up_values: Vec<f64> = collector.data.iter().map(|p| p.network_up).collect();
         let down_values: Vec<f64> = collector.data.iter().map(|p| p.network_down).collect();
@@ -67,7 +67,7 @@ impl NetworkTab {
                                         .child(
                                             div()
                                                 .text_lg()
-                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .font_weight(gpui_kit::FontWeight::SEMIBOLD)
                                                 .child(format_bytes_speed(down_speed)),
                                         )
                                         .child(div().text_xs().child("Download")),
@@ -80,7 +80,7 @@ impl NetworkTab {
                                         .child(
                                             div()
                                                 .text_lg()
-                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .font_weight(gpui_kit::FontWeight::SEMIBOLD)
                                                 .child(format_bytes_speed(up_speed)),
                                         )
                                         .child(div().text_xs().child("Upload")),
@@ -108,13 +108,13 @@ impl NetworkTab {
                                                         .x(|(t, _)| t.clone())
                                                         .y(|(_, v)| *v)
                                                         .stroke(green)
-                                                        .fill(gpui::linear_gradient(
+                                                        .fill(gpui_kit::linear_gradient(
                                                             0.0,
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 green.opacity(0.3),
                                                                 1.0,
                                                             ),
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 background.opacity(0.1),
                                                                 0.0,
                                                             ),
@@ -133,13 +133,13 @@ impl NetworkTab {
                                                         .x(|(t, _)| t.clone())
                                                         .y(|(_, v)| *v)
                                                         .stroke(yellow)
-                                                        .fill(gpui::linear_gradient(
+                                                        .fill(gpui_kit::linear_gradient(
                                                             0.0,
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 yellow.opacity(0.3),
                                                                 1.0,
                                                             ),
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 background.opacity(0.1),
                                                                 0.0,
                                                             ),
@@ -163,13 +163,13 @@ impl NetworkTab {
                                                         .x(|(t, _)| t.clone())
                                                         .y(|(_, v)| *v)
                                                         .stroke(green)
-                                                        .fill(gpui::linear_gradient(
+                                                        .fill(gpui_kit::linear_gradient(
                                                             0.0,
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 green.opacity(0.3),
                                                                 1.0,
                                                             ),
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 background.opacity(0.1),
                                                                 0.0,
                                                             ),
@@ -189,13 +189,13 @@ impl NetworkTab {
                                                         .x(|(t, _)| t.clone())
                                                         .y(|(_, v)| *v)
                                                         .stroke(yellow)
-                                                        .fill(gpui::linear_gradient(
+                                                        .fill(gpui_kit::linear_gradient(
                                                             0.0,
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 yellow.opacity(0.3),
                                                                 1.0,
                                                             ),
-                                                            gpui::linear_color_stop(
+                                                            gpui_kit::linear_color_stop(
                                                                 background.opacity(0.1),
                                                                 0.0,
                                                             ),
@@ -217,7 +217,7 @@ impl NetworkTab {
                         .flex_1()
                         .overflow_hidden()
                         .child(
-                            Table::new(&self.interface_table)
+                            DataTable::new(&self.interface_table)
                                 .bordered(false)
                                 .stripe(true),
                         ),
@@ -259,7 +259,7 @@ fn build_chart_points(values: &[f64], min_len: usize) -> Vec<(String, f64)> {
 pub fn create_interface_table(
     window: &mut Window,
     cx: &mut App,
-) -> gpui::Entity<TableState<InterfaceTableDelegate>> {
+) -> gpui_kit::Entity<TableState<InterfaceTableDelegate>> {
     let delegate = InterfaceTableDelegate::new();
     cx.new(|cx| {
         TableState::new(delegate, window, cx)
@@ -301,8 +301,8 @@ impl TableDelegate for InterfaceTableDelegate {
         self.interfaces.len()
     }
 
-    fn column(&self, col_ix: usize, _cx: &App) -> &Column {
-        &self.columns[col_ix]
+    fn column(&self, col_ix: usize, _cx: &App) -> Column {
+        self.columns[col_ix].clone()
     }
 
     fn render_td(
@@ -310,7 +310,7 @@ impl TableDelegate for InterfaceTableDelegate {
         row_ix: usize,
         col_ix: usize,
         _window: &mut Window,
-        cx: &mut gpui::Context<TableState<Self>>,
+        cx: &mut gpui_kit::Context<TableState<Self>>,
     ) -> impl IntoElement {
         let Some(interface) = self.interfaces.get(row_ix) else {
             return div().into_any_element();

--- a/src/ui/system_monitor_page/overview_tab.rs
+++ b/src/ui/system_monitor_page/overview_tab.rs
@@ -1,5 +1,5 @@
-use gpui::{IntoElement, ParentElement, Styled, div, prelude::FluentBuilder as _, px};
-use gpui_component::{Icon, v_flex};
+use gpui_kit::component::{Icon, v_flex};
+use gpui_kit::{IntoElement, ParentElement, Styled, div, prelude::FluentBuilder as _, px};
 
 use super::{
     data_collector::{DataCollector, format_bytes, format_bytes_speed},
@@ -22,8 +22,8 @@ impl OverviewTab {
     pub fn render(
         &self,
         collector: &DataCollector,
-        theme: &gpui_component::Theme,
-        viewport_width: gpui::Pixels,
+        theme: &gpui_kit::component::Theme,
+        viewport_width: gpui_kit::Pixels,
     ) -> impl IntoElement {
         let metrics = collector.get_current_metrics();
         let cpu_data: Vec<f64> = if collector.data.is_empty() {
@@ -270,9 +270,9 @@ impl OverviewTab {
 // Helper functions to create metric cards with consistent styling
 
 fn create_cpu_card(
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
     cpu_percent: f32,
-    cpu_color: gpui::Hsla,
+    cpu_color: gpui_kit::Hsla,
     cpu_data: Vec<f64>,
     collector: &DataCollector,
 ) -> MetricCard {
@@ -286,9 +286,9 @@ fn create_cpu_card(
 }
 
 fn create_memory_card(
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
     memory_percent: f32,
-    memory_color: gpui::Hsla,
+    memory_color: gpui_kit::Hsla,
     memory_data: Vec<f64>,
     collector: &DataCollector,
 ) -> MetricCard {
@@ -307,7 +307,7 @@ fn create_memory_card(
 }
 
 fn create_network_card(
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
     network_down: u64,
     network_up: u64,
     network_down_data: Vec<f64>,
@@ -321,9 +321,9 @@ fn create_network_card(
 }
 
 fn create_disk_card(
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
     disk_percent: f32,
-    disk_color: gpui::Hsla,
+    disk_color: gpui_kit::Hsla,
     collector: &DataCollector,
 ) -> MetricCard {
     let disks = collector.get_disks();
@@ -342,7 +342,7 @@ fn create_disk_card(
         .border_color(theme.border)
 }
 
-fn create_processes_card(theme: &gpui_component::Theme, process_count: usize) -> MetricCard {
+fn create_processes_card(theme: &gpui_kit::component::Theme, process_count: usize) -> MetricCard {
     MetricCard::new("Processes", format!("{}", process_count))
         .icon(Icon::new(Icon::empty()).path("icons/layout-dashboard.svg"))
         .color(theme.chart_2)
@@ -351,7 +351,7 @@ fn create_processes_card(theme: &gpui_component::Theme, process_count: usize) ->
 }
 
 fn create_battery_card(
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
     battery: super::data_collector::BatteryInfo,
     collector: &DataCollector,
 ) -> MetricCard {

--- a/src/ui/system_monitor_page/sparkline.rs
+++ b/src/ui/system_monitor_page/sparkline.rs
@@ -1,5 +1,5 @@
-use gpui::{Hsla, IntoElement, ParentElement, Pixels, Styled, div};
-use gpui_component::{chart::AreaChart, h_flex};
+use gpui_kit::component::{chart::AreaChart, h_flex};
+use gpui_kit::{Hsla, IntoElement, ParentElement, Pixels, Styled, div};
 
 #[derive(Clone)]
 pub struct Sparkline {
@@ -13,8 +13,8 @@ impl Sparkline {
     pub fn new(data: Vec<f64>) -> Self {
         Self {
             data,
-            color: gpui::Hsla::default(),
-            height: gpui::px(40.0),
+            color: gpui_kit::Hsla::default(),
+            height: gpui_kit::px(40.0),
             fill: true,
         }
     }
@@ -36,7 +36,7 @@ impl Sparkline {
 }
 
 impl IntoElement for Sparkline {
-    type Element = gpui::Div;
+    type Element = gpui_kit::Div;
 
     fn into_element(self) -> Self::Element {
         let data_points = build_chart_points(&self.data, 5);
@@ -51,16 +51,16 @@ impl IntoElement for Sparkline {
                     .y(|(_, v)| *v)
                     .stroke(self.color)
                     .fill(if self.fill {
-                        gpui::linear_gradient(
+                        gpui_kit::linear_gradient(
                             0.0,
-                            gpui::linear_color_stop(self.color.opacity(0.3), 1.0),
-                            gpui::linear_color_stop(gpui::Hsla::transparent_black(), 0.0),
+                            gpui_kit::linear_color_stop(self.color.opacity(0.3), 1.0),
+                            gpui_kit::linear_color_stop(gpui_kit::Hsla::transparent_black(), 0.0),
                         )
                     } else {
-                        gpui::linear_gradient(
+                        gpui_kit::linear_gradient(
                             0.0,
-                            gpui::linear_color_stop(gpui::Hsla::transparent_black(), 0.0),
-                            gpui::linear_color_stop(gpui::Hsla::transparent_black(), 0.0),
+                            gpui_kit::linear_color_stop(gpui_kit::Hsla::transparent_black(), 0.0),
+                            gpui_kit::linear_color_stop(gpui_kit::Hsla::transparent_black(), 0.0),
                         )
                     })
                     .tick_margin(tick_margin),
@@ -107,7 +107,7 @@ impl StatusDot {
     pub fn new(color: Hsla) -> Self {
         Self {
             color,
-            size: gpui::px(8.0),
+            size: gpui_kit::px(8.0),
         }
     }
 
@@ -118,7 +118,7 @@ impl StatusDot {
 }
 
 impl IntoElement for StatusDot {
-    type Element = gpui::Div;
+    type Element = gpui_kit::Div;
 
     fn into_element(self) -> Self::Element {
         div()
@@ -147,7 +147,7 @@ pub fn trend_color(
     current: f64,
     previous: f64,
     higher_is_better: bool,
-    theme: &gpui_component::Theme,
+    theme: &gpui_kit::component::Theme,
 ) -> Hsla {
     let diff = current - previous;
     let threshold = 0.1;

--- a/src/ui/system_monitor_page/system_monitor.rs
+++ b/src/ui/system_monitor_page/system_monitor.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use gpui::{prelude::FluentBuilder as _, *};
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Icon, h_flex,
     progress::Progress,
     tab::{Tab, TabBar},
     v_flex,
 };
+use gpui_kit::{prelude::FluentBuilder as _, *};
 use smol::Timer;
 
 use super::{
@@ -113,7 +113,7 @@ impl SystemMonitorPage {
     fn render_status_bar(
         &self,
         cx: &Context<Self>,
-        viewport_width: gpui::Pixels,
+        viewport_width: gpui_kit::Pixels,
     ) -> impl IntoElement {
         let theme = cx.theme();
         let metrics = self.collector.get_current_metrics();
@@ -179,7 +179,10 @@ impl SystemMonitorPage {
                             )
                             .when(!is_compact, |this| {
                                 this.child(
-                                    Progress::new().w(px(96.0)).h(px(6.0)).value(cpu_percent),
+                                    Progress::new("status-cpu")
+                                        .w(px(96.0))
+                                        .h(px(6.0))
+                                        .value(cpu_percent),
                                 )
                             })
                             .child(
@@ -201,7 +204,10 @@ impl SystemMonitorPage {
                             )
                             .when(!is_compact, |this| {
                                 this.child(
-                                    Progress::new().w(px(96.0)).h(px(6.0)).value(memory_percent),
+                                    Progress::new("status-memory")
+                                        .w(px(96.0))
+                                        .h(px(6.0))
+                                        .value(memory_percent),
                                 )
                             })
                             .child(
@@ -223,7 +229,10 @@ impl SystemMonitorPage {
                             )
                             .when(!is_compact, |this| {
                                 this.child(
-                                    Progress::new().w(px(96.0)).h(px(6.0)).value(disk_percent),
+                                    Progress::new("status-disk")
+                                        .w(px(96.0))
+                                        .h(px(6.0))
+                                        .value(disk_percent),
                                 )
                             })
                             .child(

--- a/src/ui/system_monitor_page/system_tab.rs
+++ b/src/ui/system_monitor_page/system_tab.rs
@@ -1,5 +1,7 @@
-use gpui::{IntoElement, ParentElement, Styled, div, px};
-use gpui_component::{chart::AreaChart, group_box::GroupBox, h_flex, progress::Progress, v_flex};
+use gpui_kit::component::{
+    chart::AreaChart, group_box::GroupBox, h_flex, progress::Progress, v_flex,
+};
+use gpui_kit::{IntoElement, ParentElement, Styled, div, px};
 
 use super::data_collector::{DataCollector, format_bytes};
 
@@ -19,8 +21,8 @@ impl SystemTab {
     pub fn render(
         &self,
         collector: &DataCollector,
-        theme: &gpui_component::Theme,
-        viewport_width: gpui::Pixels,
+        theme: &gpui_kit::component::Theme,
+        viewport_width: gpui_kit::Pixels,
     ) -> impl IntoElement {
         let cpu_data: Vec<f64> = collector.data.iter().map(|p| p.cpu).collect();
         let memory_data: Vec<f64> = collector.data.iter().map(|p| p.memory).collect();
@@ -70,7 +72,10 @@ impl SystemTab {
                                             .gap_2()
                                             .items_center()
                                             .child(
-                                                Progress::new().w(px(96.0)).h(px(8.0)).value(usage),
+                                                Progress::new(format!("cpu-core-{}", core.name))
+                                                    .w(px(96.0))
+                                                    .h(px(8.0))
+                                                    .value(usage),
                                             )
                                             .child(
                                                 div()
@@ -92,10 +97,13 @@ impl SystemTab {
                                         .y(|(_, v)| *v)
                                         .step_after()
                                         .stroke(cyan)
-                                        .fill(gpui::linear_gradient(
+                                        .fill(gpui_kit::linear_gradient(
                                             0.0,
-                                            gpui::linear_color_stop(cyan.opacity(0.3), 1.0),
-                                            gpui::linear_color_stop(background.opacity(0.1), 0.0),
+                                            gpui_kit::linear_color_stop(cyan.opacity(0.3), 1.0),
+                                            gpui_kit::linear_color_stop(
+                                                background.opacity(0.1),
+                                                0.0,
+                                            ),
                                         ))
                                         .tick_margin(10),
                                 ),
@@ -117,10 +125,13 @@ impl SystemTab {
                                         .y(|(_, v)| *v)
                                         .step_after()
                                         .stroke(blue)
-                                        .fill(gpui::linear_gradient(
+                                        .fill(gpui_kit::linear_gradient(
                                             0.0,
-                                            gpui::linear_color_stop(blue.opacity(0.3), 1.0),
-                                            gpui::linear_color_stop(background.opacity(0.1), 0.0),
+                                            gpui_kit::linear_color_stop(blue.opacity(0.3), 1.0),
+                                            gpui_kit::linear_color_stop(
+                                                background.opacity(0.1),
+                                                0.0,
+                                            ),
                                         ))
                                         .tick_margin(10),
                                 ),

--- a/src/ui/theme_edit_page/backgrounds_tab.rs
+++ b/src/ui/theme_edit_page/backgrounds_tab.rs
@@ -3,14 +3,14 @@ use crate::system::themes::theme_file_ops::{
 };
 use crate::ui::theme_edit_page::shared::{error_message, help_text, tab_container};
 use anyhow;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, IconName, Sizable,
     button::{Button, ButtonVariants},
     h_flex,
     label::Label,
     v_flex,
 };
+use gpui_kit::*;
 use smol;
 use std::path::PathBuf;
 

--- a/src/ui/theme_edit_page/browser_tab.rs
+++ b/src/ui/theme_edit_page/browser_tab.rs
@@ -4,13 +4,13 @@ use crate::types::themes::{BrowserConfig, EditingTheme};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     button::Button,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct BrowserTab {
     theme_name: String,
@@ -36,8 +36,8 @@ impl BrowserTab {
             .unwrap_or_default();
 
         // Create color picker state with current theme color
-        let theme_color =
-            Self::hex_to_hsla(&browser_config.theme_color).unwrap_or(gpui::rgb(0x0F0F19).into());
+        let theme_color = Self::hex_to_hsla(&browser_config.theme_color)
+            .unwrap_or(gpui_kit::rgb(0x0F0F19).into());
 
         let theme_color_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(theme_color));
@@ -79,7 +79,7 @@ impl BrowserTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_browser_config<F>(&mut self, updater: F)

--- a/src/ui/theme_edit_page/btop_tab.rs
+++ b/src/ui/theme_edit_page/btop_tab.rs
@@ -3,13 +3,14 @@ use crate::types::themes::{BtopConfig, EditingTheme};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
-    divider::Divider,
-    h_flex, v_flex,
+    h_flex,
+    separator::Separator,
+    v_flex,
 };
+use gpui_kit::*;
 
 pub struct BtopTab {
     theme_name: String,
@@ -78,71 +79,78 @@ impl BtopTab {
         let btop_config = theme_data.apps.btop.as_ref().cloned().unwrap_or_default();
 
         // Create color picker states with current values
-        let main_bg = Self::hex_to_hsla(&btop_config.main_bg).unwrap_or(gpui::rgb(0x0F0F19).into());
-        let main_fg = Self::hex_to_hsla(&btop_config.main_fg).unwrap_or(gpui::rgb(0xEDEDFE).into());
-        let title = Self::hex_to_hsla(&btop_config.title).unwrap_or(gpui::rgb(0x6e6e92).into());
-        let hi_fg = Self::hex_to_hsla(&btop_config.hi_fg).unwrap_or(gpui::rgb(0x33A1FF).into());
+        let main_bg =
+            Self::hex_to_hsla(&btop_config.main_bg).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
+        let main_fg =
+            Self::hex_to_hsla(&btop_config.main_fg).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
+        let title = Self::hex_to_hsla(&btop_config.title).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
+        let hi_fg = Self::hex_to_hsla(&btop_config.hi_fg).unwrap_or(gpui_kit::rgb(0x33A1FF).into());
         let selected_bg =
-            Self::hex_to_hsla(&btop_config.selected_bg).unwrap_or(gpui::rgb(0xf59e0b).into());
+            Self::hex_to_hsla(&btop_config.selected_bg).unwrap_or(gpui_kit::rgb(0xf59e0b).into());
         let selected_fg =
-            Self::hex_to_hsla(&btop_config.selected_fg).unwrap_or(gpui::rgb(0xEDEDFE).into());
+            Self::hex_to_hsla(&btop_config.selected_fg).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
         let inactive_fg =
-            Self::hex_to_hsla(&btop_config.inactive_fg).unwrap_or(gpui::rgb(0x333333).into());
+            Self::hex_to_hsla(&btop_config.inactive_fg).unwrap_or(gpui_kit::rgb(0x333333).into());
         let proc_misc =
-            Self::hex_to_hsla(&btop_config.proc_misc).unwrap_or(gpui::rgb(0x8a8a8d).into());
-        let cpu_box = Self::hex_to_hsla(&btop_config.cpu_box).unwrap_or(gpui::rgb(0x6e6e92).into());
-        let mem_box = Self::hex_to_hsla(&btop_config.mem_box).unwrap_or(gpui::rgb(0x6e6e92).into());
-        let net_box = Self::hex_to_hsla(&btop_config.net_box).unwrap_or(gpui::rgb(0x6e6e92).into());
+            Self::hex_to_hsla(&btop_config.proc_misc).unwrap_or(gpui_kit::rgb(0x8a8a8d).into());
+        let cpu_box =
+            Self::hex_to_hsla(&btop_config.cpu_box).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
+        let mem_box =
+            Self::hex_to_hsla(&btop_config.mem_box).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
+        let net_box =
+            Self::hex_to_hsla(&btop_config.net_box).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
         let proc_box =
-            Self::hex_to_hsla(&btop_config.proc_box).unwrap_or(gpui::rgb(0x6e6e92).into());
+            Self::hex_to_hsla(&btop_config.proc_box).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
         let div_line =
-            Self::hex_to_hsla(&btop_config.div_line).unwrap_or(gpui::rgb(0x6e6e92).into());
+            Self::hex_to_hsla(&btop_config.div_line).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
         let temp_start =
-            Self::hex_to_hsla(&btop_config.temp_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.temp_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let temp_mid =
-            Self::hex_to_hsla(&btop_config.temp_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.temp_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let temp_end =
-            Self::hex_to_hsla(&btop_config.temp_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.temp_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
         let cpu_start =
-            Self::hex_to_hsla(&btop_config.cpu_start).unwrap_or(gpui::rgb(0x00F59B).into());
-        let cpu_mid = Self::hex_to_hsla(&btop_config.cpu_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
-        let cpu_end = Self::hex_to_hsla(&btop_config.cpu_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.cpu_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
+        let cpu_mid =
+            Self::hex_to_hsla(&btop_config.cpu_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
+        let cpu_end =
+            Self::hex_to_hsla(&btop_config.cpu_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
         let free_start =
-            Self::hex_to_hsla(&btop_config.free_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.free_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let free_mid =
-            Self::hex_to_hsla(&btop_config.free_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.free_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let free_end =
-            Self::hex_to_hsla(&btop_config.free_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.free_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
         let cached_start =
-            Self::hex_to_hsla(&btop_config.cached_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.cached_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let cached_mid =
-            Self::hex_to_hsla(&btop_config.cached_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.cached_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let cached_end =
-            Self::hex_to_hsla(&btop_config.cached_end).unwrap_or(gpui::rgb(0xFF3366).into());
-        let available_start =
-            Self::hex_to_hsla(&btop_config.available_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.cached_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
+        let available_start = Self::hex_to_hsla(&btop_config.available_start)
+            .unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let available_mid =
-            Self::hex_to_hsla(&btop_config.available_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.available_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let available_end =
-            Self::hex_to_hsla(&btop_config.available_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.available_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
         let used_start =
-            Self::hex_to_hsla(&btop_config.used_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.used_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let used_mid =
-            Self::hex_to_hsla(&btop_config.used_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.used_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let used_end =
-            Self::hex_to_hsla(&btop_config.used_end).unwrap_or(gpui::rgb(0xFF3366).into());
-        let download_start =
-            Self::hex_to_hsla(&btop_config.download_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.used_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
+        let download_start = Self::hex_to_hsla(&btop_config.download_start)
+            .unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let download_mid =
-            Self::hex_to_hsla(&btop_config.download_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.download_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let download_end =
-            Self::hex_to_hsla(&btop_config.download_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.download_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
         let upload_start =
-            Self::hex_to_hsla(&btop_config.upload_start).unwrap_or(gpui::rgb(0x00F59B).into());
+            Self::hex_to_hsla(&btop_config.upload_start).unwrap_or(gpui_kit::rgb(0x00F59B).into());
         let upload_mid =
-            Self::hex_to_hsla(&btop_config.upload_mid).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&btop_config.upload_mid).unwrap_or(gpui_kit::rgb(0xFF66F6).into());
         let upload_end =
-            Self::hex_to_hsla(&btop_config.upload_end).unwrap_or(gpui::rgb(0xFF3366).into());
+            Self::hex_to_hsla(&btop_config.upload_end).unwrap_or(gpui_kit::rgb(0xFF3366).into());
 
         let main_bg_picker = cx.new(|cx| ColorPickerState::new(window, cx).default_value(main_bg));
         let main_fg_picker = cx.new(|cx| ColorPickerState::new(window, cx).default_value(main_fg));
@@ -765,7 +773,7 @@ impl BtopTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_btop_config<F>(&mut self, updater: F)
@@ -1101,7 +1109,7 @@ impl Render for BtopTab {
                                 )),
                         ),
                 )
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Selection Colors Section
                 .child(
                     form_section()
@@ -1128,7 +1136,7 @@ impl Render for BtopTab {
                                 )),
                         ),
                 )
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Status Colors Section
                 .child(
                     form_section()
@@ -1155,7 +1163,7 @@ impl Render for BtopTab {
                                 )),
                         ),
                 )
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Box Colors Section
                 .child(
                     form_section()
@@ -1197,7 +1205,7 @@ impl Render for BtopTab {
                                 )),
                         ),
                 )
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Gradient sections — 2 cols on wide screens, stacked on narrow
                 // Row 1: Temperature + CPU
                 .child(if wide {
@@ -1215,7 +1223,7 @@ impl Render for BtopTab {
                         .child(temp_section)
                         .child(cpu_section)
                 })
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Row 2: Free + Cached
                 .child(if wide {
                     div()
@@ -1232,7 +1240,7 @@ impl Render for BtopTab {
                         .child(free_section)
                         .child(cached_section)
                 })
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Row 3: Available + Used
                 .child(if wide {
                     div()
@@ -1249,7 +1257,7 @@ impl Render for BtopTab {
                         .child(available_section)
                         .child(used_section)
                 })
-                .child(Divider::horizontal())
+                .child(Separator::horizontal())
                 // Row 4: Download + Upload
                 .child(if wide {
                     div()

--- a/src/ui/theme_edit_page/editor_tab.rs
+++ b/src/ui/theme_edit_page/editor_tab.rs
@@ -1,20 +1,20 @@
 use crate::system::themes::theme_management::save_theme_data;
 use crate::types::themes::EditingTheme;
 use crate::ui::theme_edit_page::shared::{form_section, help_text, tab_container};
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
-    input::{Input, InputEvent, InputState},
+    input::{Editor, EditorState, InputEvent},
     v_flex,
 };
+use gpui_kit::*;
 use std::fs;
 use std::path::PathBuf;
 
 pub struct EditorTab {
     theme_name: String,
     theme_data: EditingTheme,
-    neovim_input: Entity<InputState>,
-    vscode_input: Entity<InputState>,
+    neovim_input: Entity<EditorState>,
+    vscode_input: Entity<EditorState>,
     is_saving: bool,
     error_message: Option<String>,
 }
@@ -32,15 +32,15 @@ impl EditorTab {
 
         // Create input states with code editor mode
         let neovim_input = cx.new(|cx| {
-            InputState::new(window, cx)
-                .code_editor("lua")
+            EditorState::new(window, cx)
+                .language("lua")
                 .line_number(false)
                 .default_value(&neovim_content)
         });
 
         let vscode_input = cx.new(|cx| {
-            InputState::new(window, cx)
-                .code_editor("json")
+            EditorState::new(window, cx)
+                .language("json")
                 .line_number(false)
                 .default_value(&vscode_content)
         });
@@ -241,7 +241,7 @@ impl Render for EditorTab {
                             )
                             .child(
                                 div().bg(cx.theme().background).h(px(300.)).child(
-                                    Input::new(&self.neovim_input)
+                                    Editor::new(&self.neovim_input)
                                         .bg(cx.theme().background)
                                         .border_1()
                                         .border_color(cx.theme().border)
@@ -262,7 +262,7 @@ impl Render for EditorTab {
                             )
                             .child(
                                 div().bg(cx.theme().background).h(px(200.)).child(
-                                    Input::new(&self.vscode_input)
+                                    Editor::new(&self.vscode_input)
                                         .bg(cx.theme().background)
                                         .border_1()
                                         .border_color(cx.theme().border)

--- a/src/ui/theme_edit_page/file_manager_tab.rs
+++ b/src/ui/theme_edit_page/file_manager_tab.rs
@@ -2,8 +2,8 @@ use crate::shell::theme_sh_commands::execute_bash_command;
 use crate::system::themes::theme_management::{save_theme_data, update_icons_theme};
 use crate::types::themes::EditingTheme;
 use crate::ui::theme_edit_page::shared::{form_section, help_text, tab_container};
-use gpui::*;
-use gpui_component::{ActiveTheme, button::Button, h_flex, radio::Radio, v_flex};
+use gpui_kit::component::{ActiveTheme, button::Button, h_flex, radio::Radio, v_flex};
+use gpui_kit::*;
 
 struct YaruColor {
     value: &'static str,
@@ -162,7 +162,7 @@ impl FileManagerTab {
             )
             .child(
                 // Color square
-                div().size_6().bg(gpui::rgb(color_hex)).border_1(),
+                div().size_6().bg(gpui_kit::rgb(color_hex)).border_1(),
             )
     }
 }

--- a/src/ui/theme_edit_page/general_tab.rs
+++ b/src/ui/theme_edit_page/general_tab.rs
@@ -6,8 +6,7 @@ use crate::ui::color_utils::hex_to_hsla;
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, error_message, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize, Disableable, Sizable,
     button::Button,
     color_picker::{ColorPickerEvent, ColorPickerState},
@@ -16,6 +15,7 @@ use gpui_component::{
     label::Label,
     switch::Switch,
 };
+use gpui_kit::*;
 
 pub struct GeneralTab {
     theme_data: EditingTheme,
@@ -51,7 +51,7 @@ impl GeneralTab {
 
         // Create accent color picker
         let accent_color =
-            hex_to_hsla(&theme_data.colors.accent).unwrap_or(gpui::rgb(0x33A1FF).into());
+            hex_to_hsla(&theme_data.colors.accent).unwrap_or(gpui_kit::rgb(0x33A1FF).into());
         let accent_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(accent_color));
 

--- a/src/ui/theme_edit_page/lockscreen_tab.rs
+++ b/src/ui/theme_edit_page/lockscreen_tab.rs
@@ -3,12 +3,12 @@ use crate::types::themes::{EditingTheme, HyprlockConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct LockScreenTab {
     theme_name: String,
@@ -40,15 +40,16 @@ impl LockScreenTab {
         // Create color picker states with current values
         // Note: hyprlock uses rgb format (0f0f19), not hex (#0f0f19)
         // But ColorPicker expects hex, so we add # prefix for display
-        let color = Self::rgb_to_hsla(&hyprlock_config.color).unwrap_or(gpui::rgb(0x0F0F19).into());
-        let inner_color =
-            Self::rgb_to_hsla(&hyprlock_config.inner_color).unwrap_or(gpui::rgb(0x0F0F19).into());
-        let outer_color =
-            Self::rgb_to_hsla(&hyprlock_config.outer_color).unwrap_or(gpui::rgb(0x33A0FF).into());
-        let font_color =
-            Self::rgb_to_hsla(&hyprlock_config.font_color).unwrap_or(gpui::rgb(0xFF66F5).into());
-        let check_color =
-            Self::rgb_to_hsla(&hyprlock_config.check_color).unwrap_or(gpui::rgb(0xFFEA00).into());
+        let color =
+            Self::rgb_to_hsla(&hyprlock_config.color).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
+        let inner_color = Self::rgb_to_hsla(&hyprlock_config.inner_color)
+            .unwrap_or(gpui_kit::rgb(0x0F0F19).into());
+        let outer_color = Self::rgb_to_hsla(&hyprlock_config.outer_color)
+            .unwrap_or(gpui_kit::rgb(0x33A0FF).into());
+        let font_color = Self::rgb_to_hsla(&hyprlock_config.font_color)
+            .unwrap_or(gpui_kit::rgb(0xFF66F5).into());
+        let check_color = Self::rgb_to_hsla(&hyprlock_config.check_color)
+            .unwrap_or(gpui_kit::rgb(0xFFEA00).into());
 
         let color_picker = cx.new(|cx| ColorPickerState::new(window, cx).default_value(color));
 
@@ -165,7 +166,7 @@ impl LockScreenTab {
         let g = u8::from_str_radix(&hex[3..5], 16).ok()?;
         let b = u8::from_str_radix(&hex[5..7], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn hsla_to_rgb(color: &Hsla) -> String {

--- a/src/ui/theme_edit_page/menu_tab.rs
+++ b/src/ui/theme_edit_page/menu_tab.rs
@@ -3,12 +3,12 @@ use crate::types::themes::{EditingTheme, WalkerConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct MenuTab {
     theme_name: String,
@@ -35,17 +35,17 @@ impl MenuTab {
 
         // Create color picker states with current values
         let background_color =
-            Self::hex_to_hsla(&walker_config.background).unwrap_or(gpui::rgb(0x0F0F19).into());
+            Self::hex_to_hsla(&walker_config.background).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
         let base_color =
-            Self::hex_to_hsla(&walker_config.base).unwrap_or(gpui::rgb(0x0F0F19).into());
+            Self::hex_to_hsla(&walker_config.base).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
         let border_color =
-            Self::hex_to_hsla(&walker_config.border).unwrap_or(gpui::rgb(0x33A1FF).into());
+            Self::hex_to_hsla(&walker_config.border).unwrap_or(gpui_kit::rgb(0x33A1FF).into());
         let foreground_color =
-            Self::hex_to_hsla(&walker_config.foreground).unwrap_or(gpui::rgb(0xEDEDFE).into());
+            Self::hex_to_hsla(&walker_config.foreground).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
         let text_color =
-            Self::hex_to_hsla(&walker_config.text).unwrap_or(gpui::rgb(0xEDEDFE).into());
-        let selected_text_color =
-            Self::hex_to_hsla(&walker_config.selected_text).unwrap_or(gpui::rgb(0xFF66F6).into());
+            Self::hex_to_hsla(&walker_config.text).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
+        let selected_text_color = Self::hex_to_hsla(&walker_config.selected_text)
+            .unwrap_or(gpui_kit::rgb(0xFF66F6).into());
 
         let background_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(background_color));
@@ -180,7 +180,7 @@ impl MenuTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_walker_config<F>(&mut self, updater: F)

--- a/src/ui/theme_edit_page/notification_tab.rs
+++ b/src/ui/theme_edit_page/notification_tab.rs
@@ -4,13 +4,13 @@ use crate::types::themes::{EditingTheme, MakoConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     button::Button,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct NotificationTab {
     theme_name: String,
@@ -34,11 +34,11 @@ impl NotificationTab {
 
         // Create color picker states with current values
         let text_color =
-            Self::hex_to_hsla(&mako_config.text_color).unwrap_or(gpui::rgb(0xEDEDFE).into());
+            Self::hex_to_hsla(&mako_config.text_color).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
         let border_color =
-            Self::hex_to_hsla(&mako_config.border_color).unwrap_or(gpui::rgb(0x00F59B).into());
-        let background_color =
-            Self::hex_to_hsla(&mako_config.background_color).unwrap_or(gpui::rgb(0x0F0F19).into());
+            Self::hex_to_hsla(&mako_config.border_color).unwrap_or(gpui_kit::rgb(0x00F59B).into());
+        let background_color = Self::hex_to_hsla(&mako_config.background_color)
+            .unwrap_or(gpui_kit::rgb(0x0F0F19).into());
 
         let text_color_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(text_color));
@@ -120,7 +120,7 @@ impl NotificationTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_mako_config<F>(&mut self, updater: F)

--- a/src/ui/theme_edit_page/shared.rs
+++ b/src/ui/theme_edit_page/shared.rs
@@ -1,5 +1,4 @@
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     clipboard::Clipboard,
     color_picker::{ColorPicker, ColorPickerState},
@@ -9,6 +8,7 @@ use gpui_component::{
     switch::Switch,
     v_flex,
 };
+use gpui_kit::*;
 
 pub struct FormField {
     label: String,
@@ -89,7 +89,7 @@ impl RenderOnce for ToggleField {
     fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
         let is_checked = self.is_checked;
         let on_change = self.on_change;
-        let id: gpui::SharedString = self.id.into();
+        let id: gpui_kit::SharedString = self.id.into();
 
         h_flex()
             .gap_4()

--- a/src/ui/theme_edit_page/swayosd_tab.rs
+++ b/src/ui/theme_edit_page/swayosd_tab.rs
@@ -3,12 +3,12 @@ use crate::types::themes::{EditingTheme, SwayosdConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct SwayosdTab {
     theme_name: String,
@@ -39,13 +39,15 @@ impl SwayosdTab {
 
         // Create color picker states with current values
         let background_color = Self::hex_to_hsla(&swayosd_config.background_color)
-            .unwrap_or(gpui::rgb(0x0F0F19).into());
-        let border_color =
-            Self::hex_to_hsla(&swayosd_config.border_color).unwrap_or(gpui::rgb(0x33A1FF).into());
-        let label = Self::hex_to_hsla(&swayosd_config.label).unwrap_or(gpui::rgb(0x8A8A8D).into());
-        let image = Self::hex_to_hsla(&swayosd_config.image).unwrap_or(gpui::rgb(0x8A8A8D).into());
+            .unwrap_or(gpui_kit::rgb(0x0F0F19).into());
+        let border_color = Self::hex_to_hsla(&swayosd_config.border_color)
+            .unwrap_or(gpui_kit::rgb(0x33A1FF).into());
+        let label =
+            Self::hex_to_hsla(&swayosd_config.label).unwrap_or(gpui_kit::rgb(0x8A8A8D).into());
+        let image =
+            Self::hex_to_hsla(&swayosd_config.image).unwrap_or(gpui_kit::rgb(0x8A8A8D).into());
         let progress =
-            Self::hex_to_hsla(&swayosd_config.progress).unwrap_or(gpui::rgb(0x8A8A8D).into());
+            Self::hex_to_hsla(&swayosd_config.progress).unwrap_or(gpui_kit::rgb(0x8A8A8D).into());
 
         let background_color_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(background_color));
@@ -151,7 +153,7 @@ impl SwayosdTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_swayosd_config<F>(&mut self, updater: F)

--- a/src/ui/theme_edit_page/terminal_tab.rs
+++ b/src/ui/theme_edit_page/terminal_tab.rs
@@ -4,14 +4,15 @@ use crate::types::themes::{EditingTheme, TerminalConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     button::Button,
     color_picker::{ColorPickerEvent, ColorPickerState},
-    divider::Divider,
-    h_flex, v_flex,
+    h_flex,
+    separator::Separator,
+    v_flex,
 };
+use gpui_kit::*;
 
 pub struct TerminalTab {
     theme_name: String,
@@ -51,7 +52,7 @@ impl TerminalTab {
         let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn create_color_picker(
@@ -60,7 +61,7 @@ impl TerminalTab {
         hex: &str,
         setter: impl Fn(&mut TerminalConfig, String) + 'static + Copy,
     ) -> Entity<ColorPickerState> {
-        let color = Self::hex_to_hsla(hex).unwrap_or(gpui::rgb(0x0F0F19).into());
+        let color = Self::hex_to_hsla(hex).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
         let picker = cx.new(|cx| ColorPickerState::new(window, cx).default_value(color));
 
         cx.subscribe_in(
@@ -469,7 +470,7 @@ impl Render for TerminalTab {
                                     )),
                             ),
                     )
-                    .child(Divider::horizontal())
+                    .child(Separator::horizontal())
                     // Cursor + Selection — 2 cols on wide, stacked on narrow
                     .child(if wide {
                         div()
@@ -486,7 +487,7 @@ impl Render for TerminalTab {
                             .child(cursor_section)
                             .child(selection_section)
                     })
-                    .child(Divider::horizontal())
+                    .child(Separator::horizontal())
                     // Normal + Bright — 2 cols on wide, stacked on narrow
                     .child(if wide {
                         div()

--- a/src/ui/theme_edit_page/theme_edit.rs
+++ b/src/ui/theme_edit_page/theme_edit.rs
@@ -16,14 +16,14 @@ use crate::ui::theme_edit_page::swayosd_tab::SwayosdTab;
 use crate::ui::theme_edit_page::terminal_tab::TerminalTab;
 use crate::ui::theme_edit_page::waybar_tab::WaybarTab;
 use crate::ui::theme_edit_page::windows_tab::WindowsTab;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     button::Button,
     h_flex,
     tab::{Tab, TabBar},
     v_flex,
 };
+use gpui_kit::*;
 
 const KEY_CONTEXT: &str = "ThemeEditPage";
 
@@ -132,7 +132,7 @@ impl ThemeEditPage {
 
         // Create focus handle and request focus immediately
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window);
+        focus_handle.focus(window, cx);
 
         Self {
             theme_name,

--- a/src/ui/theme_edit_page/waybar_tab.rs
+++ b/src/ui/theme_edit_page/waybar_tab.rs
@@ -3,12 +3,12 @@ use crate::types::themes::{EditingTheme, WaybarConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct WaybarTab {
     theme_name: String,
@@ -31,9 +31,9 @@ impl WaybarTab {
 
         // Create color picker states with current values
         let background_color =
-            Self::hex_to_hsla(&waybar_config.background).unwrap_or(gpui::rgb(0x0F0F19).into());
+            Self::hex_to_hsla(&waybar_config.background).unwrap_or(gpui_kit::rgb(0x0F0F19).into());
         let foreground_color =
-            Self::hex_to_hsla(&waybar_config.foreground).unwrap_or(gpui::rgb(0xEDEDFE).into());
+            Self::hex_to_hsla(&waybar_config.foreground).unwrap_or(gpui_kit::rgb(0xEDEDFE).into());
 
         let background_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(background_color));
@@ -95,7 +95,7 @@ impl WaybarTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_waybar_config<F>(&mut self, updater: F)

--- a/src/ui/theme_edit_page/windows_tab.rs
+++ b/src/ui/theme_edit_page/windows_tab.rs
@@ -3,12 +3,12 @@ use crate::types::themes::{EditingTheme, HyprlandConfig};
 use crate::ui::theme_edit_page::shared::{
     color_picker_with_clipboard, form_section, help_text, tab_container,
 };
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, Colorize,
     color_picker::{ColorPickerEvent, ColorPickerState},
     h_flex,
 };
+use gpui_kit::*;
 
 pub struct WindowsTab {
     theme_name: String,
@@ -40,9 +40,9 @@ impl WindowsTab {
         let inactive_border_hex = format!("#{}", hyprland_config.inactive_border);
 
         let active_border_color =
-            Self::hex_to_hsla(&active_border_hex).unwrap_or(gpui::rgb(0x6e6e92).into());
+            Self::hex_to_hsla(&active_border_hex).unwrap_or(gpui_kit::rgb(0x6e6e92).into());
         let inactive_border_color =
-            Self::hex_to_hsla(&inactive_border_hex).unwrap_or(gpui::rgb(0x5C5C5E).into());
+            Self::hex_to_hsla(&inactive_border_hex).unwrap_or(gpui_kit::rgb(0x5C5C5E).into());
 
         let active_border_picker =
             cx.new(|cx| ColorPickerState::new(window, cx).default_value(active_border_color));
@@ -106,7 +106,7 @@ impl WindowsTab {
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        Some(gpui::rgb(u32::from_be_bytes([0, r, g, b])).into())
+        Some(gpui_kit::rgb(u32::from_be_bytes([0, r, g, b])).into())
     }
 
     fn update_hyprland_config<F>(&mut self, updater: F)

--- a/src/ui/themes_page/theme_card.rs
+++ b/src/ui/themes_page/theme_card.rs
@@ -2,12 +2,12 @@ use crate::shell::theme_sh_commands::apply_theme;
 use crate::system::themes::theme_file_ops::{delete_theme, open_theme_folder};
 use crate::types::themes::ThemeEntry;
 use crate::ui::color_utils::hex_to_hsla;
-use gpui::prelude::*;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme, IconName, Sizable, button::*, h_flex, menu::DropdownMenu, menu::PopupMenuItem,
     v_flex,
 };
+use gpui_kit::prelude::*;
+use gpui_kit::*;
 use smol;
 use std::path::PathBuf;
 

--- a/src/ui/themes_page/theme_grid.rs
+++ b/src/ui/themes_page/theme_grid.rs
@@ -2,9 +2,9 @@ use crate::types::themes::{ThemeEntry, ThemeOrigin};
 use crate::ui::dialogs::create_theme_dialog::open_create_theme_dialog;
 use crate::ui::keyboard_nav::ListNavigationState;
 use crate::ui::themes_page::theme_card::ThemeCard;
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{ActiveTheme, button::Button, h_flex, v_flex};
+use gpui_kit::component::{ActiveTheme, button::Button, h_flex, v_flex};
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 const BREAKPOINT_SM: f32 = 768.0;
 const BREAKPOINT_LG: f32 = 1280.0;
@@ -196,7 +196,7 @@ impl Render for ThemeGrid {
             .flex()
             .flex_col()
             .flex_1()
-            .when(is_empty, |this: gpui::Div| {
+            .when(is_empty, |this: gpui_kit::Div| {
                 this.items_center().justify_center().child(
                     v_flex()
                         .items_center()
@@ -219,7 +219,7 @@ impl Render for ThemeGrid {
                         ),
                 )
             })
-            .when(!is_empty, |this: gpui::Div| {
+            .when(!is_empty, |this: gpui_kit::Div| {
                 this.child(
                     div().flex().flex_col().gap_4().w_full().min_w_0().children(
                         filtered_indices

--- a/src/ui/themes_page/themes.rs
+++ b/src/ui/themes_page/themes.rs
@@ -3,14 +3,14 @@ use crate::system::themes::system_themes::get_system_themes;
 use crate::types::themes::ThemeOrigin;
 use crate::ui::menu::app_menu;
 use crate::ui::themes_page::theme_grid::{ThemeFilter, ThemeGrid};
-use gpui::prelude::FluentBuilder;
-use gpui::*;
-use gpui_component::{
+use gpui_kit::component::{
     ActiveTheme,
     scroll::ScrollableElement,
     tab::{Tab, TabBar},
     v_flex,
 };
+use gpui_kit::prelude::FluentBuilder;
+use gpui_kit::*;
 
 const KEY_CONTEXT: &str = "ThemesPage";
 

--- a/ui_themes/theme.json
+++ b/ui_themes/theme.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://github.com/longbridge/gpui-component/raw/refs/heads/main/.theme-schema.json",
+	"$schema": "https://github.com/longbridge/gpui-kit/raw/refs/heads/main/.theme-schema.json",
 	"name": "Omarchist Theme",
 	"author": "Taha Nejad",
 	"url": "https://www.omarchist.com",


### PR DESCRIPTION
## Summary

I am the author of gpui-component. We have upgraded and renamed the library to gpui-kit and published the new crates on crates.io. Given Omarchist's popularity—and because I also enjoy using Omarchy—I wanted to help migrate this project to the latest release.

This PR:

- replaces the direct `gpui`, `gpui-component`, and `gpui-component-assets` dependencies with the unified `gpui-kit` 0.6 facade
- migrates GPUI, component, asset, application, and initialization paths to `gpui_kit`
- updates APIs changed in 0.6, including editors, data tables, separators, sidebar composition, focus handling, and progress IDs
- updates the theme schema URL to the renamed gpui-kit repository
- refreshes `Cargo.lock` for the new GPUI Kit dependency set

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --all-targets` (108 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
